### PR TITLE
fix(core): publish vault CLI bin from package dist (issue #10)

### DIFF
--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -17,7 +17,7 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "../dist/bin",
+    "outDir": "../packages/core/dist/bin",
     "rootDir": ".",
     "skipLibCheck": true
   },

--- a/bin/vault.test.ts
+++ b/bin/vault.test.ts
@@ -1,11 +1,14 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
-const distBinPath = join(rootDir, "dist", "bin", "vault.js");
+const distBinPath = join(rootDir, "packages", "core", "dist", "bin", "vault.js");
+const corePackageDir = join(rootDir, "packages", "core");
 const fixtureVaultPath = join(
   rootDir,
   "packages",
@@ -211,5 +214,44 @@ describe("vault CLI", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("Vault path is required. Provide --vault-path <path> or set VAULT_PATH in your environment.");
+  });
+
+  it("publishes vault bin from an in-package dist path", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(corePackageDir, "package.json"), "utf-8")
+    ) as { bin?: { vault?: string } };
+    const vaultBinPath = packageJson.bin?.vault;
+
+    expect(vaultBinPath).toBe("./dist/bin/vault.js");
+
+    const packDir = mkdtempSync(join(tmpdir(), "vault-engine-pack-"));
+
+    try {
+      execSync(`pnpm pack --pack-destination "${packDir}"`, {
+        cwd: corePackageDir,
+        encoding: "utf-8",
+      });
+
+      const tarballName = readdirSync(packDir).find((name) => name.endsWith(".tgz"));
+      expect(tarballName).toBeTruthy();
+
+      const tarballPath = join(packDir, tarballName ?? "");
+      const tarContents = execSync(`tar -tzf "${tarballPath}"`, {
+        cwd: rootDir,
+        encoding: "utf-8",
+      });
+      expect(tarContents).toContain("package/dist/bin/vault.js");
+
+      const packedPackageJson = JSON.parse(
+        execSync(`tar -xOf "${tarballPath}" package/package.json`, {
+          cwd: rootDir,
+          encoding: "utf-8",
+        })
+      ) as { bin?: { vault?: string } };
+
+      expect(packedPackageJson.bin?.vault).toBe("./dist/bin/vault.js");
+    } finally {
+      rmSync(packDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "vault": "../../dist/bin/vault.js"
+    "vault": "./dist/bin/vault.js"
   },
   "exports": {
     ".": {

--- a/packages/core/test/integration/abidan.integration.test.ts
+++ b/packages/core/test/integration/abidan.integration.test.ts
@@ -13,7 +13,7 @@ import { formatAppendSystemContext } from '../../../openclaw-plugin/src/formatte
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = resolve(__dirname, '../../../../');
-const distBinPath = join(rootDir, 'dist', 'bin', 'vault.js');
+const distBinPath = join(rootDir, 'packages', 'core', 'dist', 'bin', 'vault.js');
 const ABIDAN_VAULT_PATH = resolve(homedir(), 'projects/abidan-vault');
 const MIN_BM25_SCORE = 0.1;
 const MIN_COMPOUND_SCORE = 0.3;


### PR DESCRIPTION
## Summary
- fix `@ghostwater/vault-engine` `bin.vault` to an in-package path (`./dist/bin/vault.js`)
- route CLI build output into `packages/core/dist/bin` so the published package contains the executable
- add/adjust tests to verify CLI runtime path and packed tarball contents/package.json bin value

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run test:compact`
- `pnpm pack` in `packages/core` and tarball inspection confirms:
  - `package/dist/bin/vault.js` exists
  - `package/package.json` keeps `bin.vault = ./dist/bin/vault.js`

Closes #10
