### PR TITLE
fix(ci): resolve pnpm version source-of-truth conflict (issue #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Summary
- removes the explicit version input from `pnpm/action-setup` in `.github/workflows/ci.yml`
- keeps `package.json` `packageManager` pin (`pnpm@9.15.0`) as the single pnpm version source of truth in CI

## Scope
This PR is intentionally limited to issue #18 only: CI pnpm version-source conflict. No application/runtime logic changes are included.

## Validation
- `pnpm build`
- `pnpm typecheck`
- `CI=1 pnpm test`
- `npm run test:compact`

Closes #18
