### PR TITLE
fix: harden normalizeBm25 against negative raw inputs

### DIFF
--- a/packages/core/src/scoring.test.ts
+++ b/packages/core/src/scoring.test.ts
@@ -259,6 +259,11 @@ describe('normalizeBm25', () => {
     expect(normalizeBm25(2)).toBeGreaterThan(normalizeBm25(1));
     expect(normalizeBm25(5)).toBeGreaterThan(normalizeBm25(3));
   });
+
+  it('clamps negative inputs to zero', () => {
+    expect(normalizeBm25(-1)).toBe(0);
+    expect(normalizeBm25(-0.5)).toBe(0);
+  });
 });
 
 describe('computeScore', () => {

--- a/packages/core/src/scoring.ts
+++ b/packages/core/src/scoring.ts
@@ -175,7 +175,8 @@ export interface ComputeScoreOptions {
  * while preserving relative ordering.
  */
 export function normalizeBm25(raw: number): number {
-  return raw / (1 + raw);
+  const safeRaw = Math.max(0, raw);
+  return safeRaw / (1 + safeRaw);
 }
 
 /**


### PR DESCRIPTION
## Summary
- clamp negative `raw` values to `0` in exported `normalizeBm25(raw)` before normalization
- add explicit unit coverage for `normalizeBm25(-1)` and `normalizeBm25(-0.5)` returning `0`

## Validation
- `pnpm vitest run packages/core/src/scoring.test.ts`
- `pnpm typecheck`
- `npm run test:compact`

Closes #17
