### PR TITLE
feat(core): mechanically derive indexSizeBytes from serialized MiniSearch payload

### DIFF
--- a/packages/core/src/indexer.test.ts
+++ b/packages/core/src/indexer.test.ts
@@ -403,11 +403,32 @@ describe('VaultIndex', () => {
       expect(stats.typeDistribution.entity).toBe(0);
     });
 
-    it('returns estimated index size', () => {
-      index.addDocument(createTestDocument({ path: '/test/doc1.md' }));
+    it('returns serialized MiniSearch payload byte size for indexSizeBytes', () => {
+      index.addDocument(
+        createTestDocument({
+          path: '/test/doc1.md',
+          title: 'Memory Systems',
+          description: 'A short description',
+          topics: ['memory', 'systems'],
+          rawBody: 'Body text with searchable content.',
+        })
+      );
+      index.addDocument(
+        createTestDocument({
+          path: '/test/doc2.md',
+          noteType: 'research',
+          title: 'Research Notes',
+          rawBody: 'Additional indexable text for deterministic payload.',
+        })
+      );
+
+      const expectedSize = Buffer.byteLength(
+        JSON.stringify((index as any).miniSearch.toJSON()),
+        'utf8'
+      );
 
       const stats = index.getStats();
-      expect(stats.indexSizeBytes).toBeGreaterThan(0);
+      expect(stats.indexSizeBytes).toBe(expectedSize);
     });
 
     it('returns empty string lastBuildTime when not built from vault', () => {

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -98,7 +98,7 @@ export interface IndexStats {
   documentCount: number;
   /** Distribution of documents by note type */
   typeDistribution: Record<NoteType, number>;
-  /** Approximate size of the index in bytes */
+  /** UTF-8 byte size of the serialized MiniSearch index payload */
   indexSizeBytes: number;
   /** ISO timestamp of the last full index build, or empty string if not built */
   lastBuildTime: string;
@@ -252,17 +252,8 @@ export class VaultIndex {
       typeDistribution[doc.noteType]++;
     }
 
-    // Estimate index size by serializing the MiniSearch index to JSON
-    // This provides a rough approximation of actual memory usage
-    let indexSizeBytes: number;
-    try {
-      indexSizeBytes = JSON.stringify(this.miniSearch).length;
-    } catch {
-      // Fallback to rough estimate if serialization fails
-      const avgDocSize = 2000;
-      const indexOverhead = 1.5;
-      indexSizeBytes = Math.round(this.documents.size * avgDocSize * indexOverhead);
-    }
+    const serializedIndexPayload = JSON.stringify(this.miniSearch.toJSON());
+    const indexSizeBytes = Buffer.byteLength(serializedIndexPayload, 'utf8');
 
     return {
       documentCount: this.documents.size,


### PR DESCRIPTION
## Summary
- replace `indexSizeBytes` heuristic in `packages/core/src/indexer.ts` with UTF-8 byte length of the serialized MiniSearch payload
- remove hardcoded per-document estimate fallback constants from index size reporting
- add a focused unit test in `packages/core/src/indexer.test.ts` asserting `indexSizeBytes` exactly matches the mechanically-derived serialized payload size

## Scope
- limited strictly to index size reporting behavior for issue #13 and one focused test
- no broader indexing/search behavior changes

## Validation
- `pnpm vitest run packages/core/src/indexer.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `npm run test:compact`

Closes #13
