### PR TITLE
feat: issue #42 multi-vault config with per-vault policy

### DIFF
--- a/packages/openclaw-plugin/src/plugin.test.ts
+++ b/packages/openclaw-plugin/src/plugin.test.ts
@@ -889,6 +889,49 @@ describe('openclaw plugin runtime', () => {
     }
   });
 
+  it('vault_query rejects whitespace-only explicit vault targeting', async () => {
+    const primaryPath = await mkdtemp(join(tmpdir(), 'vault-tool-whitespace-'));
+    const primaryIndex = createMockIndex();
+    rebuildIndexMock.mockResolvedValueOnce(primaryIndex);
+    queryMock.mockReturnValue(createQueryResult({ query: 'whitespace vault' }));
+
+    const mod = await import('./plugin.js');
+    const registerTool = vi.fn();
+    (mod.plugin as { register: (api: { registerTool: (tool: RegisteredTool) => void }) => void }).register({
+      registerTool,
+    });
+    const tool = registerTool.mock.calls[0]?.[0] as RegisteredTool;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'primary',
+          description: 'Primary vault',
+          vaultPath: primaryPath,
+          mode: 'passive',
+        },
+      ],
+    });
+
+    try {
+      await expect(
+        tool.execute(
+          'req-whitespace-vault',
+          {
+            query: 'whitespace vault',
+            vault: '   ',
+          },
+          {
+            config,
+          }
+        )
+      ).rejects.toThrow('vault_query unavailable: unknown vault "   "');
+
+      expect(queryMock).not.toHaveBeenCalled();
+    } finally {
+      await rm(primaryPath, { recursive: true, force: true });
+    }
+  });
+
   it('missing config call does not permanently disable later valid tool initialization', async () => {
     rebuildIndexMock.mockResolvedValue(createMockIndex());
     const queryResult = createQueryResult({ query: 'recovered' });

--- a/packages/openclaw-plugin/src/plugin.test.ts
+++ b/packages/openclaw-plugin/src/plugin.test.ts
@@ -64,6 +64,26 @@ function createMockIndex(documentCount = 1): { getStats: () => { documentCount: 
   };
 }
 
+function createPluginConfig(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    injection: {
+      maxResults: 3,
+      maxTokens: 1500,
+      minScore: 0.3,
+      minBm25Score: 0.1,
+    },
+    vaults: [
+      {
+        name: 'default',
+        description: 'Default vault',
+        vaultPath: '/tmp',
+        mode: 'passive',
+      },
+    ],
+    ...overrides,
+  };
+}
+
 describe('openclaw plugin runtime', () => {
   beforeEach(async () => {
     vi.resetAllMocks();
@@ -105,8 +125,27 @@ describe('openclaw plugin runtime', () => {
         maxResults: expect.any(Object),
         noteTypes: expect.any(Object),
         context: expect.any(Object),
+        vault: expect.any(Object),
       })
     );
+  });
+
+  it('exposes config schema with required vault entries and mode enum', async () => {
+    const mod = await import('./plugin.js');
+    const schema = (mod.plugin as { manifest: { configSchema: Record<string, unknown> } }).manifest.configSchema as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+    const vaults = schema.properties?.vaults as {
+      type?: string;
+      items?: { required?: string[]; properties?: Record<string, unknown> };
+    };
+    const mode = vaults.items?.properties?.mode as { enum?: string[] };
+
+    expect(schema.required).toContain('vaults');
+    expect(vaults.type).toBe('array');
+    expect(vaults.items?.required).toEqual(['name', 'description', 'vaultPath', 'mode']);
+    expect(mode.enum).toEqual(['passive', 'query-only']);
   });
 
   it('initializes once, skips while initializing, then reuses singleton', async () => {
@@ -123,7 +162,7 @@ describe('openclaw plugin runtime', () => {
     );
     queryMock.mockReturnValue(createQueryResult());
 
-    const config = { vaultPath: '/tmp' };
+    const config = createPluginConfig();
     const messages = [{ role: 'user', content: 'where are my notes?' }];
 
     await expect(hook({ config, messages })).resolves.toBeUndefined();
@@ -142,14 +181,14 @@ describe('openclaw plugin runtime', () => {
     expect(queryMock).toHaveBeenCalledTimes(1);
   });
 
-  it('disables gracefully for missing or invalid vaultPath', async () => {
+  it('disables gracefully for missing or invalid vault config', async () => {
     const mod = await import('./plugin.js');
     const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
       .before_prompt_build;
     const logger = { warn: vi.fn() };
 
     await expect(hook({ config: {}, logger })).resolves.toBeUndefined();
-    await expect(hook({ config: { vaultPath: 123 }, logger })).resolves.toBeUndefined();
+    await expect(hook({ config: { vaults: 'bad' }, logger })).resolves.toBeUndefined();
 
     expect(rebuildIndexMock).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -168,7 +207,16 @@ describe('openclaw plugin runtime', () => {
     try {
       await expect(
         hook({
-          config: { vaultPath: emptyVaultPath },
+          config: createPluginConfig({
+            vaults: [
+              {
+                name: 'default',
+                description: 'Default vault',
+                vaultPath: emptyVaultPath,
+                mode: 'passive',
+              },
+            ],
+          }),
           messages: [{ role: 'user', content: 'test query' }],
           logger,
         })
@@ -182,7 +230,16 @@ describe('openclaw plugin runtime', () => {
 
       await expect(
         hook({
-          config: { vaultPath: emptyVaultPath },
+          config: createPluginConfig({
+            vaults: [
+              {
+                name: 'default',
+                description: 'Default vault',
+                vaultPath: emptyVaultPath,
+                mode: 'passive',
+              },
+            ],
+          }),
           messages: [{ role: 'user', content: 'test query' }],
           logger,
         })
@@ -201,7 +258,7 @@ describe('openclaw plugin runtime', () => {
     const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
       .before_prompt_build;
 
-    const config = { vaultPath: '/tmp' };
+    const config = createPluginConfig();
     const messages = [
       { role: 'user', content: 'first user' },
       { role: 'assistant', content: 'assistant response' },
@@ -234,7 +291,7 @@ describe('openclaw plugin runtime', () => {
       .before_prompt_build;
 
     const config = {
-      vaultPath: '/tmp',
+      ...createPluginConfig(),
       injection: {
         minScore: 0.77,
         minBm25Score: 0.22,
@@ -269,7 +326,14 @@ describe('openclaw plugin runtime', () => {
         entries: {
           'vault-engine': {
             config: {
-              vaultPath: '/tmp',
+              vaults: [
+                {
+                  name: 'default',
+                  description: 'Default vault',
+                  vaultPath: '/tmp',
+                  mode: 'passive',
+                },
+              ],
             },
           },
         },
@@ -282,6 +346,79 @@ describe('openclaw plugin runtime', () => {
     await hook({ config, messages });
 
     expect(rebuildIndexMock).toHaveBeenCalledWith('/tmp');
+  });
+
+  it('before_prompt_build only queries passive vaults', async () => {
+    const passivePath = await mkdtemp(join(tmpdir(), 'vault-passive-'));
+    const queryOnlyPath = await mkdtemp(join(tmpdir(), 'vault-query-only-'));
+    const passiveIndex = createMockIndex();
+    const queryOnlyIndex = createMockIndex();
+    rebuildIndexMock.mockResolvedValueOnce(passiveIndex).mockResolvedValueOnce(queryOnlyIndex);
+    queryMock.mockReturnValue(createQueryResult({ query: 'only-passive' }));
+
+    const mod = await import('./plugin.js');
+    const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
+      .before_prompt_build;
+
+    try {
+      const config = createPluginConfig({
+        vaults: [
+          {
+            name: 'primary',
+            description: 'Primary passive vault',
+            vaultPath: passivePath,
+            mode: 'passive',
+          },
+          {
+            name: 'archive',
+            description: 'Archive query-only vault',
+            vaultPath: queryOnlyPath,
+            mode: 'query-only',
+          },
+        ],
+      });
+      const messages = [{ role: 'user', content: 'passive query' }];
+
+      await hook({ config, messages });
+      await vi.waitFor(() => expect(mod.__testing.getState()).toBe('ready'));
+      await hook({ config, messages });
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      expect(queryMock).toHaveBeenCalledWith(
+        passiveIndex,
+        'passive query',
+        expect.objectContaining({ maxResults: 3 })
+      );
+    } finally {
+      await rm(passivePath, { recursive: true, force: true });
+      await rm(queryOnlyPath, { recursive: true, force: true });
+    }
+  });
+
+  it('before_prompt_build emits nothing when no passive vault is eligible', async () => {
+    rebuildIndexMock.mockResolvedValue(createMockIndex());
+    queryMock.mockReturnValue(createQueryResult());
+
+    const mod = await import('./plugin.js');
+    const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
+      .before_prompt_build;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'archive',
+          description: 'Archive query-only vault',
+          vaultPath: '/tmp',
+          mode: 'query-only',
+        },
+      ],
+    });
+
+    await hook({ config, messages: [{ role: 'user', content: 'no passive match' }] });
+    await vi.waitFor(() => expect(mod.__testing.getState()).toBe('ready'));
+    const result = await hook({ config, messages: [{ role: 'user', content: 'no passive match' }] });
+
+    expect(result).toBeUndefined();
+    expect(queryMock).not.toHaveBeenCalled();
   });
 
   it('vault_query forwards input and returns QueryResult without transformation', async () => {
@@ -305,11 +442,16 @@ describe('openclaw plugin runtime', () => {
         context: 'recall systems',
       },
       {
-        config: { vaultPath: '/tmp' },
+        config: createPluginConfig(),
       }
     );
 
-    expect(result).toBe(queryResult);
+    expect(result).toEqual(
+      expect.objectContaining({
+        query: 'memory systems',
+        results: queryResult.results,
+      })
+    );
     expect(rebuildIndexMock).toHaveBeenCalledTimes(1);
     expect(queryMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -343,7 +485,7 @@ describe('openclaw plugin runtime', () => {
         query: 'tool-first query',
       },
       {
-        config: { vaultPath: '/tmp' },
+        config: createPluginConfig(),
       }
     );
 
@@ -351,7 +493,7 @@ describe('openclaw plugin runtime', () => {
     expect(rebuildIndexMock).toHaveBeenCalledTimes(1);
 
     await hook({
-      config: { vaultPath: '/tmp' },
+      config: createPluginConfig(),
       messages: [{ role: 'user', content: 'hook query' }],
     });
 
@@ -385,10 +527,17 @@ describe('openclaw plugin runtime', () => {
     const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
       .before_prompt_build;
     const config = {
-      vaultPath: '/tmp',
-      scope: {
-        allowSessionKeys: ['agent:cpto:*'],
-      },
+      vaults: [
+        {
+          name: 'default',
+          description: 'Default vault',
+          vaultPath: '/tmp',
+          mode: 'passive',
+          scope: {
+            allowSessionKeys: ['agent:cpto:*'],
+          },
+        },
+      ],
     };
     const messages = [{ role: 'user', content: 'scope query' }];
 
@@ -424,6 +573,7 @@ describe('openclaw plugin runtime', () => {
   });
 
   it('vault_query refuses when session is out of scope', async () => {
+    rebuildIndexMock.mockResolvedValue(createMockIndex());
     const mod = await import('./plugin.js');
     const registerTool = vi.fn();
     (mod.plugin as { register: (api: { registerTool: (tool: RegisteredTool) => void }) => void }).register({
@@ -439,21 +589,29 @@ describe('openclaw plugin runtime', () => {
         },
         {
           config: {
-            vaultPath: '/tmp',
-            scope: {
-              allowSessionKeys: ['agent:cpto:*'],
-            },
+            vaults: [
+              {
+                name: 'default',
+                description: 'Default vault',
+                vaultPath: '/tmp',
+                mode: 'passive',
+                scope: {
+                  allowSessionKeys: ['agent:cpto:*'],
+                },
+              },
+            ],
           },
           sessionKey: 'agent:finance:slack:prod',
         }
       )
     ).rejects.toThrow('vault_query unavailable: current session is out of scope');
 
-    expect(rebuildIndexMock).not.toHaveBeenCalled();
+    expect(rebuildIndexMock).toHaveBeenCalledTimes(1);
     expect(queryMock).not.toHaveBeenCalled();
   });
 
   it('vault_query refuses when session key cannot be resolved and scope rules exist', async () => {
+    rebuildIndexMock.mockResolvedValue(createMockIndex());
     const mod = await import('./plugin.js');
     const registerTool = vi.fn();
     (mod.plugin as { register: (api: { registerTool: (tool: RegisteredTool) => void }) => void }).register({
@@ -469,17 +627,96 @@ describe('openclaw plugin runtime', () => {
         },
         {
           config: {
-            vaultPath: '/tmp',
-            scope: {
-              allowSessionKeys: ['agent:cpto:*'],
-            },
+            vaults: [
+              {
+                name: 'default',
+                description: 'Default vault',
+                vaultPath: '/tmp',
+                mode: 'passive',
+                scope: {
+                  allowSessionKeys: ['agent:cpto:*'],
+                },
+              },
+            ],
           },
         }
       )
     ).rejects.toThrow('vault_query unavailable: session key is required when scope rules are configured');
 
-    expect(rebuildIndexMock).not.toHaveBeenCalled();
+    expect(rebuildIndexMock).toHaveBeenCalledTimes(1);
     expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('vault_query searches all eligible vaults by default and supports explicit vault targeting', async () => {
+    const passivePath = await mkdtemp(join(tmpdir(), 'vault-tool-passive-'));
+    const queryOnlyPath = await mkdtemp(join(tmpdir(), 'vault-tool-query-only-'));
+    const passiveIndex = createMockIndex();
+    const queryOnlyIndex = createMockIndex();
+    rebuildIndexMock.mockResolvedValueOnce(passiveIndex).mockResolvedValueOnce(queryOnlyIndex);
+    queryMock.mockReturnValue(createQueryResult({ query: 'distributed query' }));
+
+    const mod = await import('./plugin.js');
+    const registerTool = vi.fn();
+    (mod.plugin as { register: (api: { registerTool: (tool: RegisteredTool) => void }) => void }).register({
+      registerTool,
+    });
+    const tool = registerTool.mock.calls[0]?.[0] as RegisteredTool;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'primary',
+          description: 'Primary passive vault',
+          vaultPath: passivePath,
+          mode: 'passive',
+        },
+        {
+          name: 'archive',
+          description: 'Archive query-only vault',
+          vaultPath: queryOnlyPath,
+          mode: 'query-only',
+          scope: {
+            allowSessionKeys: ['agent:cpto:*'],
+          },
+        },
+      ],
+    });
+
+    try {
+      await tool.execute(
+        'req-all-vaults',
+        {
+          query: 'distributed query',
+        },
+        {
+          config,
+          sessionKey: 'agent:cpto:slack:prod',
+        }
+      );
+
+      expect(queryMock).toHaveBeenCalledTimes(2);
+      expect(queryMock).toHaveBeenNthCalledWith(1, passiveIndex, 'distributed query', expect.any(Object));
+      expect(queryMock).toHaveBeenNthCalledWith(2, queryOnlyIndex, 'distributed query', expect.any(Object));
+
+      queryMock.mockClear();
+
+      await tool.execute(
+        'req-specific-vault',
+        {
+          query: 'archive only',
+          vault: 'archive',
+        },
+        {
+          config,
+          sessionKey: 'agent:cpto:slack:prod',
+        }
+      );
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      expect(queryMock).toHaveBeenCalledWith(queryOnlyIndex, 'archive only', expect.any(Object));
+    } finally {
+      await rm(passivePath, { recursive: true, force: true });
+      await rm(queryOnlyPath, { recursive: true, force: true });
+    }
   });
 
   it('missing config call does not permanently disable later valid tool initialization', async () => {
@@ -505,11 +742,16 @@ describe('openclaw plugin runtime', () => {
         query: 'recovered',
       },
       {
-        config: { vaultPath: '/tmp' },
+        config: createPluginConfig(),
       }
     );
 
-    expect(result).toBe(queryResult);
+    expect(result).toEqual(
+      expect.objectContaining({
+        query: 'recovered',
+        results: queryResult.results,
+      })
+    );
     expect(rebuildIndexMock).toHaveBeenCalledTimes(1);
     expect(mod.__testing.getState()).toBe('ready');
   });

--- a/packages/openclaw-plugin/src/plugin.test.ts
+++ b/packages/openclaw-plugin/src/plugin.test.ts
@@ -130,10 +130,10 @@ describe('openclaw plugin runtime', () => {
     );
   });
 
-  it('exposes config schema with required vault entries and mode enum', async () => {
+  it('exposes config schema with vault entry requirements, mode enum, and legacy compatibility', async () => {
     const mod = await import('./plugin.js');
     const schema = (mod.plugin as { manifest: { configSchema: Record<string, unknown> } }).manifest.configSchema as {
-      required?: string[];
+      anyOf?: Array<{ required?: string[] }>;
       properties?: Record<string, unknown>;
     };
     const vaults = schema.properties?.vaults as {
@@ -142,7 +142,7 @@ describe('openclaw plugin runtime', () => {
     };
     const mode = vaults.items?.properties?.mode as { enum?: string[] };
 
-    expect(schema.required).toContain('vaults');
+    expect(schema.anyOf).toEqual(expect.arrayContaining([{ required: ['vaults'] }, { required: ['vaultPath'] }]));
     expect(vaults.type).toBe('array');
     expect(vaults.items?.required).toEqual(['name', 'description', 'vaultPath', 'mode']);
     expect(mode.enum).toEqual(['passive', 'query-only']);
@@ -843,6 +843,49 @@ describe('openclaw plugin runtime', () => {
     } finally {
       await rm(primaryPath, { recursive: true, force: true });
       await rm(scopedPath, { recursive: true, force: true });
+    }
+  });
+
+  it('vault_query rejects explicit unknown vault names', async () => {
+    const primaryPath = await mkdtemp(join(tmpdir(), 'vault-tool-unknown-'));
+    const primaryIndex = createMockIndex();
+    rebuildIndexMock.mockResolvedValueOnce(primaryIndex);
+    queryMock.mockReturnValue(createQueryResult({ query: 'unknown vault' }));
+
+    const mod = await import('./plugin.js');
+    const registerTool = vi.fn();
+    (mod.plugin as { register: (api: { registerTool: (tool: RegisteredTool) => void }) => void }).register({
+      registerTool,
+    });
+    const tool = registerTool.mock.calls[0]?.[0] as RegisteredTool;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'primary',
+          description: 'Primary vault',
+          vaultPath: primaryPath,
+          mode: 'passive',
+        },
+      ],
+    });
+
+    try {
+      await expect(
+        tool.execute(
+          'req-unknown-vault',
+          {
+            query: 'unknown vault',
+            vault: 'does-not-exist',
+          },
+          {
+            config,
+          }
+        )
+      ).rejects.toThrow('vault_query unavailable: unknown vault "does-not-exist"');
+
+      expect(queryMock).not.toHaveBeenCalled();
+    } finally {
+      await rm(primaryPath, { recursive: true, force: true });
     }
   });
 

--- a/packages/openclaw-plugin/src/plugin.test.ts
+++ b/packages/openclaw-plugin/src/plugin.test.ts
@@ -395,6 +395,60 @@ describe('openclaw plugin runtime', () => {
     }
   });
 
+  it('before_prompt_build applies session-key scope per passive vault', async () => {
+    const primaryPath = await mkdtemp(join(tmpdir(), 'vault-passive-primary-'));
+    const scopedPath = await mkdtemp(join(tmpdir(), 'vault-passive-scoped-'));
+    const primaryIndex = createMockIndex();
+    const scopedIndex = createMockIndex();
+    rebuildIndexMock.mockResolvedValueOnce(primaryIndex).mockResolvedValueOnce(scopedIndex);
+    queryMock.mockReturnValue(createQueryResult({ query: 'scoped passive query' }));
+
+    const mod = await import('./plugin.js');
+    const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
+      .before_prompt_build;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'primary',
+          description: 'Primary passive vault',
+          vaultPath: primaryPath,
+          mode: 'passive',
+        },
+        {
+          name: 'scoped',
+          description: 'Scoped passive vault',
+          vaultPath: scopedPath,
+          mode: 'passive',
+          scope: {
+            allowSessionKeys: ['agent:cpto:*'],
+          },
+        },
+      ],
+    });
+    const messages = [{ role: 'user', content: 'scoped passive query' }];
+
+    try {
+      await hook({
+        config,
+        messages,
+        sessionKey: 'agent:finance:slack:prod',
+      });
+      await vi.waitFor(() => expect(mod.__testing.getState()).toBe('ready'));
+      await hook({
+        config,
+        messages,
+        sessionKey: 'agent:finance:slack:prod',
+      });
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      expect(queryMock).toHaveBeenCalledWith(primaryIndex, 'scoped passive query', expect.any(Object));
+      expect(queryMock).not.toHaveBeenCalledWith(scopedIndex, expect.any(String), expect.any(Object));
+    } finally {
+      await rm(primaryPath, { recursive: true, force: true });
+      await rm(scopedPath, { recursive: true, force: true });
+    }
+  });
+
   it('before_prompt_build emits nothing when no passive vault is eligible', async () => {
     rebuildIndexMock.mockResolvedValue(createMockIndex());
     queryMock.mockReturnValue(createQueryResult());
@@ -716,6 +770,79 @@ describe('openclaw plugin runtime', () => {
     } finally {
       await rm(passivePath, { recursive: true, force: true });
       await rm(queryOnlyPath, { recursive: true, force: true });
+    }
+  });
+
+  it('vault_query excludes out-of-scope vaults by default and rejects explicit out-of-scope vault', async () => {
+    const primaryPath = await mkdtemp(join(tmpdir(), 'vault-tool-primary-'));
+    const scopedPath = await mkdtemp(join(tmpdir(), 'vault-tool-scoped-'));
+    const primaryIndex = createMockIndex();
+    const scopedIndex = createMockIndex();
+    rebuildIndexMock.mockResolvedValueOnce(primaryIndex).mockResolvedValueOnce(scopedIndex);
+    queryMock.mockReturnValue(createQueryResult({ query: 'scope constrained' }));
+
+    const mod = await import('./plugin.js');
+    const registerTool = vi.fn();
+    (mod.plugin as { register: (api: { registerTool: (tool: RegisteredTool) => void }) => void }).register({
+      registerTool,
+    });
+    const tool = registerTool.mock.calls[0]?.[0] as RegisteredTool;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'primary',
+          description: 'Primary vault',
+          vaultPath: primaryPath,
+          mode: 'passive',
+        },
+        {
+          name: 'scoped',
+          description: 'Scoped vault',
+          vaultPath: scopedPath,
+          mode: 'query-only',
+          scope: {
+            allowSessionKeys: ['agent:cpto:*'],
+          },
+        },
+      ],
+    });
+
+    try {
+      await tool.execute(
+        'req-default-eligible-only',
+        {
+          query: 'scope constrained',
+        },
+        {
+          config,
+          sessionKey: 'agent:finance:slack:prod',
+        }
+      );
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      expect(queryMock).toHaveBeenCalledWith(primaryIndex, 'scope constrained', expect.any(Object));
+      expect(queryMock).not.toHaveBeenCalledWith(scopedIndex, expect.any(String), expect.any(Object));
+
+      queryMock.mockClear();
+
+      await expect(
+        tool.execute(
+          'req-explicit-oos',
+          {
+            query: 'scope constrained',
+            vault: 'scoped',
+          },
+          {
+            config,
+            sessionKey: 'agent:finance:slack:prod',
+          }
+        )
+      ).rejects.toThrow('vault_query unavailable: current session is out of scope');
+
+      expect(queryMock).not.toHaveBeenCalled();
+    } finally {
+      await rm(primaryPath, { recursive: true, force: true });
+      await rm(scopedPath, { recursive: true, force: true });
     }
   });
 

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -81,7 +81,7 @@ async function beforePromptBuild(args: BeforePromptBuildArgs): Promise<HookResul
 const configSchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['vaults'],
+  anyOf: [{ required: ['vaults'] }, { required: ['vaultPath'] }],
   properties: {
     vaults: {
       type: 'array',
@@ -109,6 +109,21 @@ const configSchema = {
               },
             },
           },
+        },
+      },
+    },
+    vaultPath: { type: 'string', minLength: 1 },
+    scope: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        allowSessionKeys: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+        },
+        denySessionKeys: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
         },
       },
     },

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -5,8 +5,7 @@ import {
   __testing as runtimeTesting,
   beginEngineInitialization,
   disableForMissingConfig,
-  evaluateSessionKeyScope,
-  getReadyEngineIndex,
+  getReadyEngineVaults,
   getUserMessages,
   parseConfig,
   resolveSessionKey,
@@ -43,11 +42,6 @@ async function beforePromptBuild(args: BeforePromptBuildArgs): Promise<HookResul
     return;
   }
 
-  const sessionScopeDecision = evaluateSessionKeyScope(config.scope, resolveSessionKey(args));
-  if (!sessionScopeDecision.inScope) {
-    return;
-  }
-
   const state = runtimeTesting.getState();
   if (state === 'disabled') {
     return;
@@ -62,8 +56,8 @@ async function beforePromptBuild(args: BeforePromptBuildArgs): Promise<HookResul
     return;
   }
 
-  const readyIndex = getReadyEngineIndex();
-  if (!readyIndex) {
+  const readyVaults = getReadyEngineVaults();
+  if (!readyVaults) {
     return;
   }
 
@@ -72,7 +66,7 @@ async function beforePromptBuild(args: BeforePromptBuildArgs): Promise<HookResul
     return;
   }
 
-  const result = runPassiveQuery(readyIndex, userMessages, config);
+  const result = runPassiveQuery(readyVaults, userMessages, config, resolveSessionKey(args));
   const appendSystemContext = formatAppendSystemContext(result, {
     maxTokens: config.injection.maxTokens,
   });
@@ -87,8 +81,37 @@ async function beforePromptBuild(args: BeforePromptBuildArgs): Promise<HookResul
 const configSchema = {
   type: 'object',
   additionalProperties: false,
+  required: ['vaults'],
   properties: {
-    vaultPath: { type: 'string', minLength: 1 },
+    vaults: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name', 'description', 'vaultPath', 'mode'],
+        properties: {
+          name: { type: 'string', minLength: 1 },
+          description: { type: 'string', minLength: 1 },
+          vaultPath: { type: 'string', minLength: 1 },
+          mode: { type: 'string', enum: ['passive', 'query-only'] },
+          scope: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              allowSessionKeys: {
+                type: 'array',
+                items: { type: 'string', minLength: 1 },
+              },
+              denySessionKeys: {
+                type: 'array',
+                items: { type: 'string', minLength: 1 },
+              },
+            },
+          },
+        },
+      },
+    },
     injection: {
       type: 'object',
       additionalProperties: false,
@@ -97,20 +120,6 @@ const configSchema = {
         maxTokens: { type: 'integer', minimum: 1 },
         minScore: { type: 'number' },
         minBm25Score: { type: 'number' },
-      },
-    },
-    scope: {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        allowSessionKeys: {
-          type: 'array',
-          items: { type: 'string', minLength: 1 },
-        },
-        denySessionKeys: {
-          type: 'array',
-          items: { type: 'string', minLength: 1 },
-        },
       },
     },
   },

--- a/packages/openclaw-plugin/src/runtime.test.ts
+++ b/packages/openclaw-plugin/src/runtime.test.ts
@@ -93,18 +93,25 @@ describe('session-key scope rules', () => {
         entries: {
           'vault-engine': {
             config: {
-              vaultPath: '/tmp',
-              scope: {
-                allowSessionKeys: ['agent:cpto:*'],
-                denySessionKeys: ['agent:cpto:slack:*'],
-              },
+              vaults: [
+                {
+                  name: 'Main',
+                  description: 'Primary vault',
+                  vaultPath: '/tmp',
+                  mode: 'passive',
+                  scope: {
+                    allowSessionKeys: ['agent:cpto:*'],
+                    denySessionKeys: ['agent:cpto:slack:*'],
+                  },
+                },
+              ],
             },
           },
         },
       },
     });
 
-    expect(parsed?.scope).toEqual({
+    expect(parsed?.vaults[0]?.scope).toEqual({
       allowSessionKeys: ['agent:cpto:*'],
       denySessionKeys: ['agent:cpto:slack:*'],
     });
@@ -116,20 +123,131 @@ describe('session-key scope rules', () => {
         entries: {
           'vault-engine': {
             config: {
-              vaultPath: '/tmp',
-              scope: {
-                allowSessionKeys: [' agent:cpto:slack:prod ', 'agent:cpto:*'],
-                denySessionKeys: [' agent:cpto:slack:sandbox:* '],
-              },
+              vaults: [
+                {
+                  name: 'Main',
+                  description: 'Primary vault',
+                  vaultPath: '/tmp',
+                  mode: 'passive',
+                  scope: {
+                    allowSessionKeys: [' agent:cpto:slack:prod ', 'agent:cpto:*'],
+                    denySessionKeys: [' agent:cpto:slack:sandbox:* '],
+                  },
+                },
+              ],
             },
           },
         },
       },
     });
 
-    expect(parsed?.scope).toEqual({
+    expect(parsed?.vaults[0]?.scope).toEqual({
       allowSessionKeys: ['agent:cpto:slack:prod', 'agent:cpto:*'],
       denySessionKeys: ['agent:cpto:slack:sandbox:*'],
+    });
+  });
+
+  it('parses valid multi-vault config with normalized values', () => {
+    const parsed = parseConfig({
+      injection: {
+        maxResults: 2.9,
+      },
+      vaults: [
+        {
+          name: ' Team Vault ',
+          description: ' Team memory ',
+          vaultPath: '~/vault/team',
+          mode: 'passive',
+          scope: {
+            allowSessionKeys: [' agent:cpto:* '],
+            denySessionKeys: [' agent:cpto:sandbox:* '],
+          },
+        },
+        {
+          name: ' Deep Archive ',
+          description: ' Query only archive ',
+          vaultPath: '/tmp/archive',
+          mode: 'query-only',
+        },
+      ],
+    });
+
+    expect(parsed).toMatchObject({
+      injection: {
+        maxResults: 2,
+      },
+      vaults: [
+        {
+          name: 'Team Vault',
+          description: 'Team memory',
+          mode: 'passive',
+          scope: {
+            allowSessionKeys: ['agent:cpto:*'],
+            denySessionKeys: ['agent:cpto:sandbox:*'],
+          },
+        },
+        {
+          name: 'Deep Archive',
+          description: 'Query only archive',
+          mode: 'query-only',
+          scope: {
+            allowSessionKeys: [],
+            denySessionKeys: [],
+          },
+        },
+      ],
+    });
+  });
+
+  it('rejects vault entries with invalid mode', () => {
+    const parsed = parseConfig({
+      vaults: [
+        {
+          name: 'Main',
+          description: 'Primary vault',
+          vaultPath: '/tmp',
+          mode: 'active',
+        },
+      ],
+    });
+
+    expect(parsed).toBeUndefined();
+  });
+
+  it('rejects vault entries with missing required fields', () => {
+    const parsed = parseConfig({
+      vaults: [
+        {
+          description: 'Primary vault',
+          vaultPath: '/tmp',
+          mode: 'passive',
+        },
+      ],
+    });
+
+    expect(parsed).toBeUndefined();
+  });
+
+  it('maps legacy single-vault config to one passive vault entry', () => {
+    const parsed = parseConfig({
+      vaultPath: '/tmp',
+      scope: {
+        allowSessionKeys: ['agent:cpto:*'],
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      vaults: [
+        {
+          name: 'default',
+          description: 'Legacy single-vault config',
+          mode: 'passive',
+          scope: {
+            allowSessionKeys: ['agent:cpto:*'],
+            denySessionKeys: [],
+          },
+        },
+      ],
     });
   });
 });

--- a/packages/openclaw-plugin/src/runtime.test.ts
+++ b/packages/openclaw-plugin/src/runtime.test.ts
@@ -228,6 +228,27 @@ describe('session-key scope rules', () => {
     expect(parsed).toBeUndefined();
   });
 
+  it('rejects multi-vault config with duplicate vault names', () => {
+    const parsed = parseConfig({
+      vaults: [
+        {
+          name: 'Main',
+          description: 'Primary vault',
+          vaultPath: '/tmp/main',
+          mode: 'passive',
+        },
+        {
+          name: 'Main',
+          description: 'Duplicate name vault',
+          vaultPath: '/tmp/other',
+          mode: 'query-only',
+        },
+      ],
+    });
+
+    expect(parsed).toBeUndefined();
+  });
+
   it('maps legacy single-vault config to one passive vault entry', () => {
     const parsed = parseConfig({
       vaultPath: '/tmp',

--- a/packages/openclaw-plugin/src/runtime.ts
+++ b/packages/openclaw-plugin/src/runtime.ts
@@ -21,10 +21,24 @@ interface ScopeConfig {
   denySessionKeys: string[];
 }
 
-export interface PluginConfig {
+export type VaultMode = 'passive' | 'query-only';
+
+export interface VaultConfig {
+  name: string;
+  description: string;
   vaultPath: string;
-  injection: InjectionConfig;
+  mode: VaultMode;
   scope: ScopeConfig;
+}
+
+export interface PluginConfig {
+  vaults: VaultConfig[];
+  injection: InjectionConfig;
+}
+
+export interface ReadyVaultEngine {
+  vault: VaultConfig;
+  index: VaultIndex;
 }
 
 export interface HookMessage {
@@ -35,7 +49,7 @@ export interface HookMessage {
 type EngineState =
   | { status: 'idle' }
   | { status: 'initializing'; promise: Promise<void> }
-  | { status: 'ready'; index: VaultIndex }
+  | { status: 'ready'; vaults: ReadyVaultEngine[] }
   | { status: 'disabled'; reason: string };
 
 const DEFAULT_INJECTION_CONFIG: InjectionConfig = {
@@ -51,6 +65,8 @@ const DEFAULT_SCOPE_CONFIG: ScopeConfig = {
 };
 
 const FIXED_QUERY_MAX_RESULTS = 3;
+const LEGACY_DEFAULT_VAULT_NAME = 'default';
+const LEGACY_DEFAULT_VAULT_DESCRIPTION = 'Legacy single-vault config';
 
 const warnedKeys = new Set<string>();
 let engineState: EngineState = { status: 'idle' };
@@ -117,7 +133,7 @@ function resolveConfigInput(input: unknown): unknown {
     return input;
   }
 
-  if ('vaultPath' in input || 'injection' in input) {
+  if ('vaults' in input || 'vaultPath' in input || 'injection' in input || 'scope' in input) {
     return input;
   }
 
@@ -147,34 +163,101 @@ function resolveConfigInput(input: unknown): unknown {
   return input;
 }
 
+function normalizeScopeConfig(input: unknown): ScopeConfig {
+  const scopeInput = isRecord(input) ? input : {};
+  return {
+    allowSessionKeys: toPatternList(scopeInput.allowSessionKeys ?? DEFAULT_SCOPE_CONFIG.allowSessionKeys),
+    denySessionKeys: toPatternList(scopeInput.denySessionKeys ?? DEFAULT_SCOPE_CONFIG.denySessionKeys),
+  };
+}
+
+function asNonEmptyTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parseVaultEntry(value: unknown): VaultConfig | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const name = asNonEmptyTrimmedString(value.name);
+  const description = asNonEmptyTrimmedString(value.description);
+  const rawVaultPath = asNonEmptyTrimmedString(value.vaultPath);
+  const mode = value.mode;
+  if (!name || !description || !rawVaultPath || (mode !== 'passive' && mode !== 'query-only')) {
+    return undefined;
+  }
+
+  return {
+    name,
+    description,
+    vaultPath: normalizePath(rawVaultPath),
+    mode,
+    scope: normalizeScopeConfig(value.scope),
+  };
+}
+
+function parseLegacySingleVaultConfig(value: Record<string, unknown>): VaultConfig | undefined {
+  const rawVaultPath = asNonEmptyTrimmedString(value.vaultPath);
+  if (!rawVaultPath) {
+    return undefined;
+  }
+
+  return {
+    name: LEGACY_DEFAULT_VAULT_NAME,
+    description: LEGACY_DEFAULT_VAULT_DESCRIPTION,
+    vaultPath: normalizePath(rawVaultPath),
+    mode: 'passive',
+    scope: normalizeScopeConfig(value.scope),
+  };
+}
+
 export function parseConfig(input: unknown): PluginConfig | undefined {
   const resolved = resolveConfigInput(input);
   if (!isRecord(resolved)) {
     return undefined;
   }
 
-  const rawVaultPath = resolved.vaultPath;
-  if (typeof rawVaultPath !== 'string' || rawVaultPath.trim() === '') {
-    return undefined;
+  const injectionInput = isRecord(resolved.injection) ? resolved.injection : {};
+
+  let vaults: VaultConfig[] | undefined;
+  if (Array.isArray(resolved.vaults)) {
+    if (resolved.vaults.length === 0) {
+      return undefined;
+    }
+
+    const parsedVaults: VaultConfig[] = [];
+    for (const rawVault of resolved.vaults) {
+      const parsedVault = parseVaultEntry(rawVault);
+      if (!parsedVault) {
+        return undefined;
+      }
+      parsedVaults.push(parsedVault);
+    }
+
+    vaults = parsedVaults;
+  } else {
+    const legacyVault = parseLegacySingleVaultConfig(resolved);
+    if (!legacyVault) {
+      return undefined;
+    }
+    vaults = [legacyVault];
   }
 
-  const injectionInput = isRecord(resolved.injection) ? resolved.injection : {};
-  const scopeInput = isRecord(resolved.scope) ? resolved.scope : {};
-  const config: PluginConfig = {
-    vaultPath: normalizePath(rawVaultPath.trim()),
+  return {
+    vaults,
     injection: {
       maxResults: Math.max(1, Math.floor(toFiniteNumber(injectionInput.maxResults, DEFAULT_INJECTION_CONFIG.maxResults))),
       maxTokens: Math.max(1, Math.floor(toFiniteNumber(injectionInput.maxTokens, DEFAULT_INJECTION_CONFIG.maxTokens))),
       minScore: toFiniteNumber(injectionInput.minScore, DEFAULT_INJECTION_CONFIG.minScore),
       minBm25Score: toFiniteNumber(injectionInput.minBm25Score, DEFAULT_INJECTION_CONFIG.minBm25Score),
     },
-    scope: {
-      allowSessionKeys: toPatternList(scopeInput.allowSessionKeys ?? DEFAULT_SCOPE_CONFIG.allowSessionKeys),
-      denySessionKeys: toPatternList(scopeInput.denySessionKeys ?? DEFAULT_SCOPE_CONFIG.denySessionKeys),
-    },
   };
-
-  return config;
 }
 
 function globToRegExp(pattern: string): RegExp {
@@ -308,41 +391,51 @@ export function getUserMessages(messages: HookMessage[] | undefined): string[] {
 }
 
 async function initializeEngine(config: PluginConfig, logger: Logger | undefined): Promise<void> {
-  try {
-    const stats = await stat(config.vaultPath);
-    if (!stats.isDirectory()) {
-      throw new Error('vaultPath is not a directory');
+  const readyVaults: ReadyVaultEngine[] = [];
+
+  for (const vault of config.vaults) {
+    try {
+      const stats = await stat(vault.vaultPath);
+      if (!stats.isDirectory()) {
+        throw new Error('vaultPath is not a directory');
+      }
+    } catch {
+      warnOnce(
+        logger,
+        `invalid-vault-path:${vault.vaultPath}`,
+        `[vault-engine] invalid vaultPath for vault "${vault.name}": "${vault.vaultPath}". Skipping this vault.`
+      );
+      continue;
     }
-  } catch {
-    engineState = { status: 'disabled', reason: 'invalid-vault-path' };
-    warnOnce(
-      logger,
-      'invalid-vault-path',
-      `[vault-engine] invalid vaultPath "${config.vaultPath}". Disabling plugin.`
-    );
+
+    try {
+      const index = await rebuildIndex(vault.vaultPath);
+      const stats = index.getStats();
+      if (stats.documentCount === 0) {
+        warnOnce(
+          logger,
+          `empty-vault:${vault.vaultPath}`,
+          `[vault-engine] no markdown notes were indexed from vault "${vault.name}" at "${vault.vaultPath}". It will stay enabled but return no results until notes are available.`
+        );
+      }
+
+      readyVaults.push({ vault, index });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      warnOnce(
+        logger,
+        `engine-init-failed:${vault.vaultPath}`,
+        `[vault-engine] failed to initialize vault "${vault.name}" (${reason}). Skipping this vault.`
+      );
+    }
+  }
+
+  if (readyVaults.length === 0) {
+    engineState = { status: 'disabled', reason: 'no-ready-vaults' };
     return;
   }
 
-  try {
-    const index = await rebuildIndex(config.vaultPath);
-    const stats = index.getStats();
-    if (stats.documentCount === 0) {
-      warnOnce(
-        logger,
-        `empty-vault:${config.vaultPath}`,
-        `[vault-engine] no markdown notes were indexed from "${config.vaultPath}". Plugin will stay enabled but inject no context until notes are available.`
-      );
-    }
-    engineState = { status: 'ready', index };
-  } catch (error) {
-    engineState = { status: 'disabled', reason: 'engine-init-failed' };
-    const reason = error instanceof Error ? error.message : String(error);
-    warnOnce(
-      logger,
-      'engine-init-failed',
-      `[vault-engine] failed to initialize vault engine (${reason}). Disabling plugin.`
-    );
-  }
+  engineState = { status: 'ready', vaults: readyVaults };
 }
 
 function startInitialization(config: PluginConfig, logger: Logger | undefined): void {
@@ -357,8 +450,8 @@ function startInitialization(config: PluginConfig, logger: Logger | undefined): 
 export function disableForMissingConfig(logger: Logger | undefined): void {
   warnOnce(
     logger,
-    'missing-vault-path',
-    '[vault-engine] missing or invalid config.vaultPath. Skipping vault context/tool for this call.'
+    'missing-vault-config',
+    '[vault-engine] missing or invalid config.vaults (or legacy config.vaultPath). Skipping vault context/tool for this call.'
   );
 }
 
@@ -366,18 +459,18 @@ export function beginEngineInitialization(config: PluginConfig, logger: Logger |
   startInitialization(config, logger);
 }
 
-export function getReadyEngineIndex(): VaultIndex | undefined {
+export function getReadyEngineVaults(): ReadyVaultEngine[] | undefined {
   if (engineState.status !== 'ready') {
     return undefined;
   }
 
-  return engineState.index;
+  return engineState.vaults;
 }
 
 export async function ensureEngineReady(
   config: PluginConfig,
   logger: Logger | undefined
-): Promise<VaultIndex | undefined> {
+): Promise<ReadyVaultEngine[] | undefined> {
   if (engineState.status === 'disabled') {
     return undefined;
   }
@@ -394,19 +487,74 @@ export async function ensureEngineReady(
     return undefined;
   }
 
-  return engineState.index;
+  return engineState.vaults;
 }
 
-export function runPassiveQuery(index: VaultIndex, userMessages: string[], config: PluginConfig): QueryResult {
+function mergeQueryResults(queryText: string, results: QueryResult[], maxResults: number): QueryResult {
+  const merged = results
+    .flatMap((result) => result.results)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, Math.max(1, Math.floor(maxResults)));
+
+  const tier = results.length > 0 ? Math.min(...results.map((result) => result.tier)) : 0;
+  const latencyMs = results.reduce((total, result) => total + result.latencyMs, 0);
+
+  return {
+    results: merged,
+    tier,
+    latencyMs,
+    query: queryText,
+  };
+}
+
+function filterEligibleVaults(
+  readyVaults: ReadyVaultEngine[],
+  sessionKey: string | undefined,
+  options?: { mode?: VaultMode; name?: string }
+): ReadyVaultEngine[] {
+  return readyVaults.filter((readyVault) => {
+    if (options?.mode && readyVault.vault.mode !== options.mode) {
+      return false;
+    }
+
+    if (options?.name && readyVault.vault.name !== options.name) {
+      return false;
+    }
+
+    const scopeDecision = evaluateSessionKeyScope(readyVault.vault.scope, sessionKey);
+    return scopeDecision.inScope;
+  });
+}
+
+export function runPassiveQuery(
+  readyVaults: ReadyVaultEngine[],
+  userMessages: string[],
+  config: PluginConfig,
+  sessionKey: string | undefined
+): QueryResult {
   const queryText = userMessages[userMessages.length - 1];
   const context = userMessages.slice(-3).join('\n\n');
+  const passiveVaults = filterEligibleVaults(readyVaults, sessionKey, { mode: 'passive' });
 
-  return query(index, queryText, {
-    maxResults: FIXED_QUERY_MAX_RESULTS,
-    minScore: config.injection.minScore,
-    minBm25Score: config.injection.minBm25Score,
-    context,
-  });
+  if (passiveVaults.length === 0) {
+    return {
+      results: [],
+      tier: 0,
+      latencyMs: 0,
+      query: queryText,
+    };
+  }
+
+  const results = passiveVaults.map((readyVault) =>
+    query(readyVault.index, queryText, {
+      maxResults: FIXED_QUERY_MAX_RESULTS,
+      minScore: config.injection.minScore,
+      minBm25Score: config.injection.minBm25Score,
+      context,
+    })
+  );
+
+  return mergeQueryResults(queryText, results, config.injection.maxResults);
 }
 
 interface ToolQueryInput {
@@ -414,14 +562,60 @@ interface ToolQueryInput {
   maxResults?: number;
   noteTypes?: string[];
   context?: string;
+  vault?: string;
 }
 
-export function runToolQuery(index: VaultIndex, input: ToolQueryInput): QueryResult {
-  return query(index, input.query, {
-    maxResults: input.maxResults,
-    noteTypes: input.noteTypes as import('@ghostwater/vault-engine').NoteType[] | undefined,
-    context: input.context,
-  });
+export function getEligibleVaultsForTool(
+  readyVaults: ReadyVaultEngine[],
+  sessionKey: string | undefined,
+  requestedVaultName?: string
+): { vaults: ReadyVaultEngine[]; reason?: SessionScopeDecision['reason'] | 'vault-not-found' } {
+  const normalizedName = requestedVaultName?.trim();
+  if (normalizedName) {
+    const matchingVault = readyVaults.find((readyVault) => readyVault.vault.name === normalizedName);
+    if (!matchingVault) {
+      return { vaults: [], reason: 'vault-not-found' };
+    }
+
+    const decision = evaluateSessionKeyScope(matchingVault.vault.scope, sessionKey);
+    if (!decision.inScope) {
+      return { vaults: [], reason: decision.reason };
+    }
+
+    return { vaults: [matchingVault] };
+  }
+
+  const eligibleVaults = filterEligibleVaults(readyVaults, sessionKey);
+  if (eligibleVaults.length > 0) {
+    return { vaults: eligibleVaults };
+  }
+
+  const hadScopeRules = readyVaults.some(
+    (readyVault) =>
+      readyVault.vault.scope.allowSessionKeys.length > 0 || readyVault.vault.scope.denySessionKeys.length > 0
+  );
+
+  if (!hadScopeRules) {
+    return { vaults: [] };
+  }
+
+  if (!sessionKey) {
+    return { vaults: [], reason: 'missing-session-key' };
+  }
+
+  return { vaults: [], reason: 'default-deny-allowlist' };
+}
+
+export function runToolQuery(readyVaults: ReadyVaultEngine[], input: ToolQueryInput): QueryResult {
+  const results = readyVaults.map((readyVault) =>
+    query(readyVault.index, input.query, {
+      maxResults: input.maxResults,
+      noteTypes: input.noteTypes as import('@ghostwater/vault-engine').NoteType[] | undefined,
+      context: input.context,
+    })
+  );
+
+  return mergeQueryResults(input.query, results, input.maxResults ?? FIXED_QUERY_MAX_RESULTS);
 }
 
 export const __testing = {

--- a/packages/openclaw-plugin/src/runtime.ts
+++ b/packages/openclaw-plugin/src/runtime.ts
@@ -575,7 +575,12 @@ export function getEligibleVaultsForTool(
   sessionKey: string | undefined,
   requestedVaultName?: string
 ): { vaults: ReadyVaultEngine[]; reason?: SessionScopeDecision['reason'] | 'vault-not-found' } {
+  const hasExplicitVaultTarget = typeof requestedVaultName === 'string';
   const normalizedName = requestedVaultName?.trim();
+  if (hasExplicitVaultTarget && !normalizedName) {
+    return { vaults: [], reason: 'vault-not-found' };
+  }
+
   if (normalizedName) {
     const matchingVault = readyVaults.find((readyVault) => readyVault.vault.name === normalizedName);
     if (!matchingVault) {

--- a/packages/openclaw-plugin/src/runtime.ts
+++ b/packages/openclaw-plugin/src/runtime.ts
@@ -232,11 +232,16 @@ export function parseConfig(input: unknown): PluginConfig | undefined {
     }
 
     const parsedVaults: VaultConfig[] = [];
+    const seenVaultNames = new Set<string>();
     for (const rawVault of resolved.vaults) {
       const parsedVault = parseVaultEntry(rawVault);
       if (!parsedVault) {
         return undefined;
       }
+      if (seenVaultNames.has(parsedVault.name)) {
+        return undefined;
+      }
+      seenVaultNames.add(parsedVault.name);
       parsedVaults.push(parsedVault);
     }
 

--- a/packages/openclaw-plugin/src/tool.ts
+++ b/packages/openclaw-plugin/src/tool.ts
@@ -59,7 +59,7 @@ export function registerVaultQueryTool(api: ToolRegisterApi): void {
           items: { type: 'string' },
         },
         context: { type: 'string' },
-        vault: { type: 'string', minLength: 1 },
+        vault: { type: 'string', minLength: 1, pattern: '\\S' },
       },
     },
     async execute(_requestId: string, input: VaultQueryToolInput, context?: ToolExecutionContext): Promise<QueryResult> {

--- a/packages/openclaw-plugin/src/tool.ts
+++ b/packages/openclaw-plugin/src/tool.ts
@@ -2,7 +2,7 @@ import type { QueryResult } from '@ghostwater/vault-engine';
 
 import {
   ensureEngineReady,
-  evaluateSessionKeyScope,
+  getEligibleVaultsForTool,
   parseConfig,
   resolveSessionKey,
   runToolQuery,
@@ -18,6 +18,7 @@ interface VaultQueryToolInput {
   maxResults?: number;
   noteTypes?: string[];
   context?: string;
+  vault?: string;
 }
 
 interface ToolExecutionContext {
@@ -58,29 +59,34 @@ export function registerVaultQueryTool(api: ToolRegisterApi): void {
           items: { type: 'string' },
         },
         context: { type: 'string' },
+        vault: { type: 'string', minLength: 1 },
       },
     },
     async execute(_requestId: string, input: VaultQueryToolInput, context?: ToolExecutionContext): Promise<QueryResult> {
       const config = parseConfig(context?.config);
       if (!config) {
         disableForMissingConfig(context?.logger);
-        throw new Error('vault_query requires a valid plugin config with vaultPath');
+        throw new Error('vault_query requires a valid plugin config with vaults');
       }
 
-      const sessionScopeDecision = evaluateSessionKeyScope(config.scope, resolveSessionKey(context));
-      if (!sessionScopeDecision.inScope) {
-        if (sessionScopeDecision.reason === 'missing-session-key') {
+      const readyVaults = await ensureEngineReady(config, context?.logger);
+      if (!readyVaults) {
+        throw new Error('vault_query unavailable: vault engine is disabled or failed to initialize');
+      }
+
+      const sessionKey = resolveSessionKey(context);
+      const eligible = getEligibleVaultsForTool(readyVaults, sessionKey, input.vault);
+      if (eligible.vaults.length === 0) {
+        if (eligible.reason === 'vault-not-found') {
+          throw new Error(`vault_query unavailable: unknown vault "${input.vault}"`);
+        }
+        if (eligible.reason === 'missing-session-key') {
           throw new Error('vault_query unavailable: session key is required when scope rules are configured');
         }
         throw new Error('vault_query unavailable: current session is out of scope');
       }
 
-      const index = await ensureEngineReady(config, context?.logger);
-      if (!index) {
-        throw new Error('vault_query unavailable: vault engine is disabled or failed to initialize');
-      }
-
-      return runToolQuery(index, input);
+      return runToolQuery(eligible.vaults, input);
     },
   });
 }


### PR DESCRIPTION
## Summary
Implements issue #42 with scope limited to openclaw plugin config/model/retrieval behavior.

- replace single-vault plugin config shape with normalized `vaults[]` runtime model (`name`, `description`, `vaultPath`, `mode`, optional per-vault `scope`)
- update plugin `configSchema` to validate `vaults[]` entries and `mode` enum (`passive|query-only`)
- implement legacy single-vault compatibility mapping (`vaultPath` + optional global `scope`) into one passive vault entry
- update passive retrieval to query only eligible passive vaults by per-vault scope and emit nothing when no passive results qualify
- update `vault_query` to search all eligible vaults by default and support optional explicit `vault` selection
- add focused tests covering config parsing, legacy mapping, multi-vault policies, and default/all-vault query behavior

## Validation
Executed on branch `feat/issue-42-multi-vault-config`:

- `pnpm vitest run packages/openclaw-plugin/src/plugin.test.ts packages/openclaw-plugin/src/runtime.test.ts` -> pass (`2` files, `34` tests)
- `pnpm vitest run packages/openclaw-plugin/src/index.test.ts packages/openclaw-plugin/src/formatter.test.ts` -> pass (`2` files, `9` tests)
- `pnpm typecheck` -> pass
- `pnpm build` -> pass
- `npm run test:compact` -> pass (`14` files, `347` tests)

## Scope control
- no grouped rendering polish changes
- no unrelated package behavior changes outside `packages/openclaw-plugin`
