### PR TITLE
feat: issue #43 STORY-1 global passive candidate selection

### DIFF
--- a/packages/openclaw-plugin/src/formatter.test.ts
+++ b/packages/openclaw-plugin/src/formatter.test.ts
@@ -83,6 +83,19 @@ describe('formatAppendSystemContext', () => {
     expect(output).not.toContain('### Archive');
   });
 
+  it('preserves legacy flat formatting when vault metadata is absent', () => {
+    const result = createQueryResult([
+      createScoredDocument('Legacy A', 'a'),
+      createScoredDocument('Legacy B', 'b'),
+    ]);
+
+    const output = formatAppendSystemContext(result, { maxTokens: 1500 });
+    expect(output).toContain('[belief|high] Legacy A\na');
+    expect(output).toContain('[belief|high] Legacy B\nb');
+    expect(output).not.toContain('### ');
+    expect(output).not.toContain('Unknown Vault');
+  });
+
   it('groups interleaved passive winners under a single heading per vault', () => {
     const result = createQueryResult([
       createScoredDocument('Team 1', 'a', 0.95, {}, 'Team'),

--- a/packages/openclaw-plugin/src/formatter.test.ts
+++ b/packages/openclaw-plugin/src/formatter.test.ts
@@ -2,6 +2,7 @@ import type { QueryResult, ScoredDocument } from '@ghostwater/vault-engine';
 import { describe, expect, it } from 'vitest';
 
 import { formatAppendSystemContext } from './formatter.js';
+import type { VaultMode } from './runtime.js';
 
 function estimateTokenCount(text: string): number {
   return Math.ceil(text.length / 4);
@@ -11,9 +12,10 @@ function createScoredDocument(
   title: string,
   description?: string,
   score = 1,
-  overrides: Partial<ScoredDocument['doc']> = {}
+  overrides: Partial<ScoredDocument['doc']> = {},
+  vaultName?: string
 ): ScoredDocument {
-  return {
+  const result = {
     doc: {
       path: `/vault/${title}.md`,
       slug: title.toLowerCase(),
@@ -34,6 +36,8 @@ function createScoredDocument(
     matchedFields: ['title'],
     explanation: 'test',
   };
+
+  return vaultName ? Object.assign(result, { vaultName }) : result;
 }
 
 function createQueryResult(results: ScoredDocument[]): QueryResult {
@@ -45,27 +49,49 @@ function createQueryResult(results: ScoredDocument[]): QueryResult {
   };
 }
 
+const defaultAvailableVaults: Array<{ name: string; description: string; mode: VaultMode }> = [
+  { name: 'Team', description: 'Primary team memory', mode: 'passive' },
+];
+
 describe('formatAppendSystemContext', () => {
-  it('formats output with header and frontmatter description only', () => {
+  it('formats output with explanation, available vaults, and grouped vault headings', () => {
     const result = createQueryResult([
-      createScoredDocument('Belief A', 'Frontmatter description'),
-      createScoredDocument('Belief B'),
+      createScoredDocument('Belief A', 'Frontmatter description', 0.9, {}, 'Team'),
+      createScoredDocument('Belief B', undefined, 0.8, {}, 'Team'),
     ]);
 
-    expect(formatAppendSystemContext(result, { maxTokens: 1500 })).toBe(
-      '## Vault Context\n\n[belief|high] Belief A\nFrontmatter description\n\n[belief|high] Belief B'
+    expect(formatAppendSystemContext(result, { maxTokens: 1500, availableVaults: defaultAvailableVaults })).toBe(
+      '## Vault Context\n\nVaults are curated knowledge bases. Use `vault_query` when you need deeper or targeted retrieval.\n\nAvailable vaults:\n- Team: Primary team memory\n\n### Team\n\n[belief|high] Belief A\nFrontmatter description\n\n[belief|high] Belief B'
     );
   });
 
-  it('limits output to top 3 results', () => {
+  it('lists query-only vaults but excludes them from grouped passive results', () => {
     const result = createQueryResult([
-      createScoredDocument('A', 'a'),
-      createScoredDocument('B', 'b'),
-      createScoredDocument('C', 'c'),
-      createScoredDocument('D', 'd'),
+      createScoredDocument('Passive A', 'a', 0.9, {}, 'Team'),
+      createScoredDocument('Passive B', 'b', 0.8, {}, 'Team'),
     ]);
 
-    const output = formatAppendSystemContext(result, { maxTokens: 1500 });
+    const output = formatAppendSystemContext(result, {
+      maxTokens: 1500,
+      availableVaults: [
+        { name: 'Team', description: 'Primary team memory', mode: 'passive' },
+        { name: 'Archive', description: 'Deep archive', mode: 'query-only' },
+      ],
+    });
+    expect(output).toContain('Available vaults:\n- Team: Primary team memory\n- Archive (query-only): Deep archive');
+    expect(output).toContain('### Team');
+    expect(output).not.toContain('### Archive');
+  });
+
+  it('limits output to top 3 results before grouping', () => {
+    const result = createQueryResult([
+      createScoredDocument('A', 'a', 1, {}, 'Vault 1'),
+      createScoredDocument('B', 'b', 1, {}, 'Vault 1'),
+      createScoredDocument('C', 'c', 1, {}, 'Vault 2'),
+      createScoredDocument('D', 'd', 1, {}, 'Vault 2'),
+    ]);
+
+    const output = formatAppendSystemContext(result, { maxTokens: 1500, availableVaults: defaultAvailableVaults });
     expect(output).toBeDefined();
     expect(output).toContain('[belief|high] A');
     expect(output).toContain('[belief|high] B');
@@ -76,17 +102,19 @@ describe('formatAppendSystemContext', () => {
   it('enforces per-result 400-token cap and total budget within 1500', () => {
     const longDescription = 'x'.repeat(5000);
     const result = createQueryResult([
-      createScoredDocument('A', longDescription),
-      createScoredDocument('B', longDescription),
-      createScoredDocument('C', longDescription),
+      createScoredDocument('A', longDescription, 1, {}, 'Vault 1'),
+      createScoredDocument('B', longDescription, 1, {}, 'Vault 1'),
+      createScoredDocument('C', longDescription, 1, {}, 'Vault 2'),
     ]);
 
-    const output = formatAppendSystemContext(result, { maxTokens: 99999 });
+    const output = formatAppendSystemContext(result, { maxTokens: 99999, availableVaults: defaultAvailableVaults });
     expect(output).toBeDefined();
-    const blocks = output!.split('\n\n');
-    expect(blocks).toHaveLength(4);
+    const blocks = output!
+      .split('\n\n')
+      .filter((block) => block.startsWith('['));
+    expect(blocks).toHaveLength(3);
 
-    for (const block of blocks.slice(1)) {
+    for (const block of blocks) {
       expect(estimateTokenCount(block)).toBeLessThanOrEqual(400);
     }
     expect(estimateTokenCount(output!)).toBeLessThanOrEqual(1500);
@@ -95,12 +123,12 @@ describe('formatAppendSystemContext', () => {
   it('drops weakest results first when budget is exceeded', () => {
     const mediumDescription = 'y'.repeat(900);
     const result = createQueryResult([
-      createScoredDocument('Strongest', mediumDescription, 0.9),
-      createScoredDocument('Middle', mediumDescription, 0.6),
-      createScoredDocument('Weakest', mediumDescription, 0.3),
+      createScoredDocument('Strongest', mediumDescription, 0.9, {}, 'Vault 1'),
+      createScoredDocument('Middle', mediumDescription, 0.6, {}, 'Vault 2'),
+      createScoredDocument('Weakest', mediumDescription, 0.3, {}, 'Vault 3'),
     ]);
 
-    const output = formatAppendSystemContext(result, { maxTokens: 500 });
+    const output = formatAppendSystemContext(result, { maxTokens: 700, availableVaults: defaultAvailableVaults });
     expect(output).toBeDefined();
     expect(output).toContain('[belief|high] Strongest');
     expect(output).toContain('[belief|high] Middle');
@@ -114,22 +142,22 @@ describe('formatAppendSystemContext', () => {
         confidence: 'high',
         maturity: 'seedling',
         status: 'proven',
-      }),
+      }, 'Team'),
       createScoredDocument('Belief Maturity', undefined, 1, {
         noteType: 'belief',
         confidence: undefined,
         maturity: 'evergreen',
         status: 'proven',
-      }),
+      }, 'Team'),
       createScoredDocument('Belief Bare', undefined, 1, {
         noteType: 'belief',
         confidence: undefined,
         maturity: undefined,
         status: undefined,
-      }),
+      }, 'Team'),
     ]);
 
-    const output = formatAppendSystemContext(result, { maxTokens: 1500 });
+    const output = formatAppendSystemContext(result, { maxTokens: 1500, availableVaults: defaultAvailableVaults });
     expect(output).toContain('[belief|high] Belief Confidence');
     expect(output).not.toContain('[belief|unknown] Belief Confidence');
     expect(output).toContain('[belief|evergreen] Belief Maturity');
@@ -141,18 +169,18 @@ describe('formatAppendSystemContext', () => {
       createScoredDocument('Research Proven', undefined, 1, {
         noteType: 'research',
         status: 'proven',
-      }),
+      }, 'Team'),
       createScoredDocument('Research Bare', undefined, 1, {
         noteType: 'research',
         status: undefined,
-      }),
+      }, 'Team'),
       createScoredDocument('Experience Completed', undefined, 1, {
         noteType: 'experience',
         status: 'completed',
-      }),
+      }, 'Team'),
     ]);
 
-    const output = formatAppendSystemContext(result, { maxTokens: 1500 });
+    const output = formatAppendSystemContext(result, { maxTokens: 1500, availableVaults: defaultAvailableVaults });
     expect(output).toContain('[research|proven] Research Proven');
     expect(output).toContain('[research] Research Bare');
     expect(output).toContain('[experience|completed] Experience Completed');
@@ -166,15 +194,17 @@ describe('formatAppendSystemContext', () => {
         provenance: undefined,
         date: undefined,
         updatedAt: undefined,
-      }),
+      }, 'Team'),
     ]);
 
-    const output = formatAppendSystemContext(result, { maxTokens: 1500 });
+    const output = formatAppendSystemContext(result, { maxTokens: 1500, availableVaults: defaultAvailableVaults });
     expect(output).toContain('[entity] Entity Bare');
     expect(output).not.toContain('[entity|');
   });
 
   it('returns undefined when there are no results', () => {
-    expect(formatAppendSystemContext(createQueryResult([]), { maxTokens: 1500 })).toBeUndefined();
+    expect(
+      formatAppendSystemContext(createQueryResult([]), { maxTokens: 1500, availableVaults: defaultAvailableVaults })
+    ).toBeUndefined();
   });
 });

--- a/packages/openclaw-plugin/src/formatter.test.ts
+++ b/packages/openclaw-plugin/src/formatter.test.ts
@@ -83,6 +83,27 @@ describe('formatAppendSystemContext', () => {
     expect(output).not.toContain('### Archive');
   });
 
+  it('groups interleaved passive winners under a single heading per vault', () => {
+    const result = createQueryResult([
+      createScoredDocument('Team 1', 'a', 0.95, {}, 'Team'),
+      createScoredDocument('Archive 1', 'b', 0.9, {}, 'Archive'),
+      createScoredDocument('Team 2', 'c', 0.85, {}, 'Team'),
+    ]);
+
+    const output = formatAppendSystemContext(result, {
+      maxTokens: 1500,
+      availableVaults: [
+        { name: 'Team', description: 'Primary team memory', mode: 'passive' },
+        { name: 'Archive', description: 'Secondary memory', mode: 'passive' },
+      ],
+    });
+
+    expect(output).toBeDefined();
+    expect(output).toContain('### Team\n\n[belief|high] Team 1\na\n\n[belief|high] Team 2\nc');
+    expect(output).toContain('### Archive\n\n[belief|high] Archive 1\nb');
+    expect(output!.match(/### Team/g)).toHaveLength(1);
+  });
+
   it('limits output to top 3 results before grouping', () => {
     const result = createQueryResult([
       createScoredDocument('A', 'a', 1, {}, 'Vault 1'),
@@ -206,5 +227,12 @@ describe('formatAppendSystemContext', () => {
     expect(
       formatAppendSystemContext(createQueryResult([]), { maxTokens: 1500, availableVaults: defaultAvailableVaults })
     ).toBeUndefined();
+  });
+
+  it('returns undefined when no passive result survives token budgeting', () => {
+    const veryLongDescription = 'z'.repeat(5000);
+    const result = createQueryResult([createScoredDocument('Too Long', veryLongDescription, 0.9, {}, 'Team')]);
+
+    expect(formatAppendSystemContext(result, { maxTokens: 60, availableVaults: defaultAvailableVaults })).toBeUndefined();
   });
 });

--- a/packages/openclaw-plugin/src/formatter.ts
+++ b/packages/openclaw-plugin/src/formatter.ts
@@ -68,11 +68,11 @@ interface PassiveResultWithVaultMetadata extends ScoredDocument {
 }
 
 interface FormattedPassiveChunk {
-  vaultName: string;
+  vaultName?: string;
   text: string;
 }
 
-function renderGroupedResultSections(chunks: FormattedPassiveChunk[]): string[] {
+function renderGroupedResultSections(chunks: Array<{ vaultName: string; text: string }>): string[] {
   const sectionsByVault = new Map<string, string[]>();
   const vaultOrder: string[] = [];
   for (const chunk of chunks) {
@@ -93,6 +93,19 @@ function renderGroupedResultSections(chunks: FormattedPassiveChunk[]): string[] 
   return sections;
 }
 
+function renderResultSections(chunks: FormattedPassiveChunk[]): string[] {
+  const hasVaultMetadata = chunks.some((chunk) => chunk.vaultName);
+  if (!hasVaultMetadata) {
+    return chunks.map((chunk) => chunk.text);
+  }
+
+  const groupedChunks = chunks.map((chunk) => ({
+    vaultName: chunk.vaultName ?? 'Unknown Vault',
+    text: chunk.text,
+  }));
+  return renderGroupedResultSections(groupedChunks);
+}
+
 export function formatAppendSystemContext(
   queryResult: QueryResult,
   options: InjectionFormatOptions
@@ -108,7 +121,7 @@ export function formatAppendSystemContext(
     const rawChunk = formatResult(result);
     const text = truncateToTokenCap(rawChunk, PER_RESULT_TOKEN_CAP);
     return {
-      vaultName: result.vaultName ?? 'Unknown Vault',
+      vaultName: result.vaultName,
       text,
     };
   });
@@ -125,8 +138,8 @@ export function formatAppendSystemContext(
 
   let keptChunks = [...formattedChunks];
   while (keptChunks.length > 0) {
-    const groupedSections = renderGroupedResultSections(keptChunks);
-    const rendered = [...baseParts, ...groupedSections].join(SEPARATOR);
+    const sections = renderResultSections(keptChunks);
+    const rendered = [...baseParts, ...sections].join(SEPARATOR);
     if (estimateTokenCount(rendered) <= availableTokens) {
       return rendered;
     }

--- a/packages/openclaw-plugin/src/formatter.ts
+++ b/packages/openclaw-plugin/src/formatter.ts
@@ -1,7 +1,13 @@
 import type { QueryResult, ScoredDocument } from '@ghostwater/vault-engine';
+import type { VaultMode } from './runtime.js';
 
 export interface InjectionFormatOptions {
   maxTokens: number;
+  availableVaults?: Array<{
+    name: string;
+    description: string;
+    mode: VaultMode;
+  }>;
 }
 
 const HEADER = '## Vault Context';
@@ -9,6 +15,8 @@ const MAX_RESULTS = 3;
 const PER_RESULT_TOKEN_CAP = 400;
 const TOTAL_TOKEN_CAP = 1500;
 const SEPARATOR = '\n\n';
+const EXPLANATION =
+  'Vaults are curated knowledge bases. Use `vault_query` when you need deeper or targeted retrieval.';
 
 function estimateTokenCount(text: string): number {
   return Math.ceil(text.length / 4);
@@ -50,6 +58,36 @@ function formatResult(result: ScoredDocument): string {
   return `${header}\n${result.doc.description}`;
 }
 
+function formatAvailableVault(vault: { name: string; description: string; mode: VaultMode }): string {
+  const modeLabel = vault.mode === 'query-only' ? ' (query-only)' : '';
+  return `- ${vault.name}${modeLabel}: ${vault.description}`;
+}
+
+interface PassiveResultWithVaultMetadata extends ScoredDocument {
+  vaultName?: string;
+}
+
+interface FormattedPassiveChunk {
+  vaultName: string;
+  text: string;
+}
+
+function renderGroupedResultSections(chunks: FormattedPassiveChunk[]): string[] {
+  const sections: string[] = [];
+  let currentVaultName: string | undefined;
+
+  for (const chunk of chunks) {
+    const vaultName = chunk.vaultName;
+    if (vaultName !== currentVaultName) {
+      sections.push(`### ${vaultName}`);
+      currentVaultName = vaultName;
+    }
+    sections.push(chunk.text);
+  }
+
+  return sections;
+}
+
 export function formatAppendSystemContext(
   queryResult: QueryResult,
   options: InjectionFormatOptions
@@ -59,33 +97,36 @@ export function formatAppendSystemContext(
   }
 
   const availableTokens = Math.min(TOTAL_TOKEN_CAP, Math.max(1, Math.floor(options.maxTokens)));
-  const selectedResults = queryResult.results.slice(0, MAX_RESULTS);
-  const usedTokens = estimateTokenCount(HEADER);
-  if (usedTokens > availableTokens) {
-    return undefined;
-  }
+  const selectedResults = queryResult.results.slice(0, MAX_RESULTS) as PassiveResultWithVaultMetadata[];
 
-  const chunks: Array<{ text: string; tokens: number }> = [];
-  for (const result of selectedResults) {
+  const formattedChunks = selectedResults.map((result) => {
     const rawChunk = formatResult(result);
     const text = truncateToTokenCap(rawChunk, PER_RESULT_TOKEN_CAP);
-    const tokens = estimateTokenCount(text);
-    chunks.push({ text, tokens });
-  }
+    return {
+      vaultName: result.vaultName ?? 'Unknown Vault',
+      text,
+    };
+  });
 
-  const separatorTokens = estimateTokenCount(SEPARATOR);
-  let totalTokens = usedTokens + chunks.reduce((acc, chunk) => acc + chunk.tokens + separatorTokens, 0);
-  while (totalTokens > availableTokens && chunks.length > 0) {
-    const removed = chunks.pop();
-    if (!removed) {
-      break;
-    }
-    totalTokens -= removed.tokens + separatorTokens;
+  const availableVaults = options.availableVaults ?? [];
+  const baseParts = [HEADER, EXPLANATION];
+  if (availableVaults.length > 0) {
+    baseParts.push(['Available vaults:', ...availableVaults.map((vault) => formatAvailableVault(vault))].join('\n'));
   }
-
-  if (chunks.length === 0) {
+  const baseText = baseParts.join(SEPARATOR);
+  if (estimateTokenCount(baseText) > availableTokens) {
     return undefined;
   }
 
-  return [HEADER, ...chunks.map((chunk) => chunk.text)].join(SEPARATOR);
+  let keptChunks = [...formattedChunks];
+  while (keptChunks.length > 0) {
+    const groupedSections = renderGroupedResultSections(keptChunks);
+    const rendered = [...baseParts, ...groupedSections].join(SEPARATOR);
+    if (estimateTokenCount(rendered) <= availableTokens) {
+      return rendered;
+    }
+    keptChunks.pop();
+  }
+
+  return undefined;
 }

--- a/packages/openclaw-plugin/src/formatter.ts
+++ b/packages/openclaw-plugin/src/formatter.ts
@@ -73,18 +73,23 @@ interface FormattedPassiveChunk {
 }
 
 function renderGroupedResultSections(chunks: FormattedPassiveChunk[]): string[] {
-  const sections: string[] = [];
-  let currentVaultName: string | undefined;
-
+  const sectionsByVault = new Map<string, string[]>();
+  const vaultOrder: string[] = [];
   for (const chunk of chunks) {
-    const vaultName = chunk.vaultName;
-    if (vaultName !== currentVaultName) {
-      sections.push(`### ${vaultName}`);
-      currentVaultName = vaultName;
+    const existing = sectionsByVault.get(chunk.vaultName);
+    if (existing) {
+      existing.push(chunk.text);
+      continue;
     }
-    sections.push(chunk.text);
+    sectionsByVault.set(chunk.vaultName, [chunk.text]);
+    vaultOrder.push(chunk.vaultName);
   }
 
+  const sections: string[] = [];
+  for (const vaultName of vaultOrder) {
+    sections.push(`### ${vaultName}`);
+    sections.push(...(sectionsByVault.get(vaultName) ?? []));
+  }
   return sections;
 }
 

--- a/packages/openclaw-plugin/src/plugin.test.ts
+++ b/packages/openclaw-plugin/src/plugin.test.ts
@@ -381,7 +381,7 @@ describe('openclaw plugin runtime', () => {
 
       await hook({ config, messages });
       await vi.waitFor(() => expect(mod.__testing.getState()).toBe('ready'));
-      await hook({ config, messages });
+      const result = await hook({ config, messages });
 
       expect(queryMock).toHaveBeenCalledTimes(1);
       expect(queryMock).toHaveBeenCalledWith(
@@ -389,6 +389,14 @@ describe('openclaw plugin runtime', () => {
         'passive query',
         expect.objectContaining({ maxResults: 3 })
       );
+      expect(result).toEqual({
+        appendSystemContext: expect.stringContaining('Available vaults:'),
+      });
+      const appendSystemContext = (result as { appendSystemContext?: string }).appendSystemContext;
+      expect(appendSystemContext).toContain('- primary: Primary passive vault');
+      expect(appendSystemContext).toContain('- archive (query-only): Archive query-only vault');
+      expect(appendSystemContext).toContain('### primary');
+      expect(appendSystemContext).not.toContain('### archive');
     } finally {
       await rm(passivePath, { recursive: true, force: true });
       await rm(queryOnlyPath, { recursive: true, force: true });

--- a/packages/openclaw-plugin/src/plugin.test.ts
+++ b/packages/openclaw-plugin/src/plugin.test.ts
@@ -475,6 +475,33 @@ describe('openclaw plugin runtime', () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
+  it('before_prompt_build emits nothing when passive candidates do not survive query filtering', async () => {
+    rebuildIndexMock.mockResolvedValue(createMockIndex());
+    queryMock.mockReturnValue(createQueryResult({ results: [] }));
+
+    const mod = await import('./plugin.js');
+    const hook = (mod.plugin as { hooks: { before_prompt_build: (args: unknown) => Promise<unknown> } }).hooks
+      .before_prompt_build;
+    const config = createPluginConfig({
+      vaults: [
+        {
+          name: 'primary',
+          description: 'Primary passive vault',
+          vaultPath: '/tmp',
+          mode: 'passive',
+        },
+      ],
+    });
+    const messages = [{ role: 'user', content: 'strict thresholds' }];
+
+    await hook({ config, messages });
+    await vi.waitFor(() => expect(mod.__testing.getState()).toBe('ready'));
+    const result = await hook({ config, messages });
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+
   it('vault_query forwards input and returns QueryResult without transformation', async () => {
     rebuildIndexMock.mockResolvedValue(createMockIndex());
     const queryResult = createQueryResult({ query: 'memory systems' });

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   __testing as runtimeTesting,
   beginEngineInitialization,
   disableForMissingConfig,
+  getEligibleVaultsForTool,
   getReadyEngineVaults,
   getUserMessages,
   parseConfig,
@@ -66,9 +67,12 @@ async function beforePromptBuild(args: BeforePromptBuildArgs): Promise<HookResul
     return;
   }
 
-  const result = runPassiveQuery(readyVaults, userMessages, config, resolveSessionKey(args));
+  const sessionKey = resolveSessionKey(args);
+  const result = runPassiveQuery(readyVaults, userMessages, config, sessionKey);
+  const visibleVaults = getEligibleVaultsForTool(readyVaults, sessionKey).vaults.map((readyVault) => readyVault.vault);
   const appendSystemContext = formatAppendSystemContext(result, {
     maxTokens: config.injection.maxTokens,
+    availableVaults: visibleVaults,
   });
 
   if (!appendSystemContext) {

--- a/packages/openclaw-plugin/src/runtime.test.ts
+++ b/packages/openclaw-plugin/src/runtime.test.ts
@@ -1,6 +1,80 @@
-import { describe, expect, it } from 'vitest';
+import type { QueryResult, ScoredDocument, VaultDocument, VaultIndex } from '@ghostwater/vault-engine';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { evaluateSessionKeyScope, parseConfig } from './runtime.js';
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}));
+vi.mock('@ghostwater/vault-engine', () => ({
+  query: queryMock,
+  rebuildIndex: vi.fn(),
+}));
+
+import type { PluginConfig, ReadyVaultEngine, VaultConfig, VaultMode } from './runtime.js';
+import { evaluateSessionKeyScope, parseConfig, runPassiveQuery } from './runtime.js';
+
+function createDoc(title: string): VaultDocument {
+  return {
+    path: `/tmp/${title}.md`,
+    slug: title.toLowerCase(),
+    noteType: 'belief',
+    title,
+    description: `${title} description`,
+    status: 'proven',
+    confidence: 'high',
+    bodySections: [],
+    rawBody: '',
+  };
+}
+
+function createScored(title: string, score: number): ScoredDocument {
+  return {
+    doc: createDoc(title),
+    score,
+    bm25Raw: 1,
+    bm25Normalized: 0.5,
+    typeBoost: 0.1,
+    confidenceModifier: 0.1,
+    matchedFields: ['title'],
+    explanation: 'test',
+  };
+}
+
+function createQueryResult(results: ScoredDocument[]): QueryResult {
+  return {
+    results,
+    tier: 0,
+    latencyMs: 1,
+    query: 'q',
+  };
+}
+
+function createReadyVault(name: string, mode: VaultMode, description: string): ReadyVaultEngine {
+  return {
+    vault: {
+      name,
+      mode,
+      description,
+      vaultPath: `/tmp/${name}`,
+      scope: {
+        allowSessionKeys: [],
+        denySessionKeys: [],
+      },
+    } satisfies VaultConfig,
+    index: { getStats: () => ({ documentCount: 1 }) } as unknown as VaultIndex,
+  };
+}
+
+function createPassiveConfig(maxResults = 3): PluginConfig {
+  return {
+    vaults: [],
+    injection: {
+      maxResults,
+      maxTokens: 1500,
+      minScore: 0.3,
+      minBm25Score: 0.1,
+    },
+  };
+}
 
 describe('session-key scope rules', () => {
   it('supports exact allow', () => {
@@ -270,5 +344,75 @@ describe('session-key scope rules', () => {
         },
       ],
     });
+  });
+});
+
+describe('runPassiveQuery multi-vault passive selection', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('ranks passive winners globally across vaults and records vault metadata per result', () => {
+    const passiveA = createReadyVault('primary', 'passive', 'Primary vault');
+    const passiveB = createReadyVault('secondary', 'passive', 'Secondary vault');
+
+    queryMock.mockImplementation((index: VaultIndex) => {
+      if (index === passiveA.index) {
+        return createQueryResult([
+          createScored('Primary Mid', 0.65),
+          createScored('Primary Low', 0.4),
+        ]);
+      }
+      return createQueryResult([
+        createScored('Secondary Top', 0.9),
+        createScored('Secondary Low', 0.2),
+      ]);
+    });
+
+    const result = runPassiveQuery(
+      [passiveA, passiveB],
+      ['user asks for memory'],
+      createPassiveConfig(3),
+      'agent:any'
+    );
+
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(result.results.map((item) => item.doc.title)).toEqual([
+      'Secondary Top',
+      'Primary Mid',
+      'Primary Low',
+    ]);
+    expect(result.results[0]).toMatchObject({
+      vaultName: 'secondary',
+      vaultDescription: 'Secondary vault',
+    });
+    expect(result.results[1]).toMatchObject({
+      vaultName: 'primary',
+      vaultDescription: 'Primary vault',
+    });
+  });
+
+  it('excludes query-only vaults from passive candidate generation and budget consumption', () => {
+    const passive = createReadyVault('primary', 'passive', 'Primary vault');
+    const queryOnly = createReadyVault('archive', 'query-only', 'Archive vault');
+
+    queryMock.mockImplementation((index: VaultIndex) => {
+      if (index === passive.index) {
+        return createQueryResult([createScored('Passive Winner', 0.55)]);
+      }
+      return createQueryResult([createScored('Query-Only Should Not Appear', 0.99)]);
+    });
+
+    const result = runPassiveQuery(
+      [passive, queryOnly],
+      ['user asks for memory'],
+      createPassiveConfig(1),
+      undefined
+    );
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock).toHaveBeenCalledWith(passive.index, 'user asks for memory', expect.any(Object));
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.doc.title).toBe('Passive Winner');
   });
 });

--- a/packages/openclaw-plugin/src/runtime.ts
+++ b/packages/openclaw-plugin/src/runtime.ts
@@ -2,7 +2,7 @@ import { stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 
-import type { QueryResult, VaultIndex } from '@ghostwater/vault-engine';
+import type { QueryResult, ScoredDocument, VaultIndex } from '@ghostwater/vault-engine';
 import { query, rebuildIndex } from '@ghostwater/vault-engine';
 
 interface Logger {
@@ -40,6 +40,13 @@ export interface ReadyVaultEngine {
   vault: VaultConfig;
   index: VaultIndex;
 }
+
+export interface PassiveCandidateVaultMetadata {
+  vaultName: string;
+  vaultDescription: string;
+}
+
+export type PassiveCandidate = ScoredDocument & PassiveCandidateVaultMetadata;
 
 export interface HookMessage {
   role?: string;
@@ -550,14 +557,23 @@ export function runPassiveQuery(
     };
   }
 
-  const results = passiveVaults.map((readyVault) =>
-    query(readyVault.index, queryText, {
+  const results = passiveVaults.map((readyVault) => {
+    const vaultResult = query(readyVault.index, queryText, {
       maxResults: FIXED_QUERY_MAX_RESULTS,
       minScore: config.injection.minScore,
       minBm25Score: config.injection.minBm25Score,
       context,
-    })
-  );
+    });
+
+    return {
+      ...vaultResult,
+      results: vaultResult.results.map((result) => ({
+        ...result,
+        vaultName: readyVault.vault.name,
+        vaultDescription: readyVault.vault.description,
+      })),
+    };
+  });
 
   return mergeQueryResults(queryText, results, config.injection.maxResults);
 }


### PR DESCRIPTION
## Summary
- annotate passive candidates with source vault name/description during passive query execution
- keep passive candidate generation limited to session-visible passive vaults, excluding query-only from passive budget
- preserve global score-based winner selection across all passive candidates
- update passive formatter output to include vault explanation, available vault list (including query-only), and grouped per-vault result sections
- keep formatter backwards-compatible for direct callers that do not pass vault listing metadata

## Tests
- added runtime unit tests for global multi-vault ranking + metadata and query-only exclusion
- added formatter tests for grouped rendering, available vault listing, query-only listing behavior, and token-budget trimming
- added plugin hook test asserting before_prompt_build returns undefined when passive query returns no qualifying results
- ran npm run typecheck
- ran npm run build
- ran npm run test:compact
