### PR TITLE
fix: CI follow-up for issue #47 package-bundle/openclaw test blockers

### DIFF
--- a/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
+++ b/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
@@ -9,9 +9,10 @@ const repoRoot = resolve(__dirname, '../../..');
 const pluginPackageDir = resolve(repoRoot, 'packages/openclaw-plugin');
 const pluginRuntimeDistPath = resolve(pluginPackageDir, 'dist/runtime.js');
 const runtimeImportEdgePatterns = [
-  /(?:^|\s)from\s*['"]@ghostwater\/vault-engine['"]/,
-  /(?:^|\s)import\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
-  /(?:^|\s)require\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
+  /(?:^|[^\w$])import\s*['"]@ghostwater\/vault-engine['"]/,
+  /(?:^|[^\w$])from\s*['"]@ghostwater\/vault-engine['"]/,
+  /(?:^|[^\w$])import\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
+  /(?:^|[^\w$])require\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
 ];
 
 function hasRuntimeImportEdge(source: string): boolean {

--- a/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
+++ b/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
@@ -3,20 +3,60 @@ import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
+import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = resolve(__dirname, '../../..');
 const pluginPackageDir = resolve(repoRoot, 'packages/openclaw-plugin');
 const pluginRuntimeDistPath = resolve(pluginPackageDir, 'dist/runtime.js');
-const runtimeImportEdgePatterns = [
-  /(?:^|[^\w$])import\s*['"]@ghostwater\/vault-engine['"]/,
-  /(?:^|[^\w$])from\s*['"]@ghostwater\/vault-engine['"]/,
-  /(?:^|[^\w$])import\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
-  /(?:^|[^\w$])require\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
-];
+const workspacePackageName = '@ghostwater/vault-engine';
 
 function hasRuntimeImportEdge(source: string): boolean {
-  return runtimeImportEdgePatterns.some((pattern) => pattern.test(source));
+  const sourceFile = ts.createSourceFile('runtime.js', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  let hasEdge = false;
+
+  const isWorkspaceLiteral = (node: ts.Expression | undefined): boolean =>
+    Boolean(node && ts.isStringLiteral(node) && node.text === workspacePackageName);
+
+  const visit = (node: ts.Node): void => {
+    if (hasEdge) {
+      return;
+    }
+
+    if (ts.isImportDeclaration(node) && isWorkspaceLiteral(node.moduleSpecifier)) {
+      hasEdge = true;
+      return;
+    }
+
+    if (ts.isExportDeclaration(node) && isWorkspaceLiteral(node.moduleSpecifier)) {
+      hasEdge = true;
+      return;
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'require' &&
+      isWorkspaceLiteral(node.arguments[0])
+    ) {
+      hasEdge = true;
+      return;
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      isWorkspaceLiteral(node.arguments[0])
+    ) {
+      hasEdge = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return hasEdge;
 }
 
 describe('openclaw plugin packaging CI follow-up', () => {

--- a/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
+++ b/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -26,12 +26,10 @@ describe('openclaw plugin packaging CI follow-up', () => {
       const installDir = mkdtempSync(join(tmpdir(), 'openclaw-plugin-install-'));
 
       try {
-        if (!existsSync(pluginRuntimeDistPath)) {
-          execSync('pnpm build', {
-            cwd: pluginPackageDir,
-            stdio: 'pipe',
-          });
-        }
+        execSync('pnpm build', {
+          cwd: pluginPackageDir,
+          stdio: 'pipe',
+        });
 
         execSync(`pnpm pack --pack-destination "${packDir}"`, {
           cwd: pluginPackageDir,
@@ -78,7 +76,7 @@ describe('openclaw plugin packaging CI follow-up', () => {
             ].join(' '),
             { cwd: installDir, stdio: 'pipe' }
           )
-        ).not.toThrowError(/Cannot find (module|package) ['"]@ghostwater\/vault-engine['"]/);
+        ).not.toThrow();
       } finally {
         rmSync(packDir, { recursive: true, force: true });
         rmSync(installDir, { recursive: true, force: true });

--- a/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
+++ b/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
@@ -1,29 +1,88 @@
-import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
-const repoRoot = resolve(__dirname, "../../..");
-const coreDistIndex = resolve(repoRoot, "packages/core/dist/index.js");
-const pluginPackageDir = resolve(repoRoot, "packages/openclaw-plugin");
+const repoRoot = resolve(__dirname, '../../..');
+const pluginPackageDir = resolve(repoRoot, 'packages/openclaw-plugin');
+const pluginRuntimeDistPath = resolve(pluginPackageDir, 'dist/runtime.js');
+const runtimeImportEdgePatterns = [
+  /(?:^|\s)from\s*['"]@ghostwater\/vault-engine['"]/,
+  /(?:^|\s)import\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
+  /(?:^|\s)require\s*\(\s*['"]@ghostwater\/vault-engine['"]\s*\)/,
+];
 
-describe("openclaw plugin packaging CI isolation", () => {
+function hasRuntimeImportEdge(source: string): boolean {
+  return runtimeImportEdgePatterns.some((pattern) => pattern.test(source));
+}
+
+describe('openclaw plugin packaging CI follow-up', () => {
   it(
-    "does not delete core build artifacts when running plugin clean",
+    'packs runtime artifacts without @ghostwater/vault-engine edges and loads in an external install',
     () => {
-      execSync("pnpm build", {
-        cwd: repoRoot,
-        stdio: "pipe",
-      });
-      expect(existsSync(coreDistIndex)).toBe(true);
+      const packDir = mkdtempSync(join(tmpdir(), 'openclaw-plugin-pack-'));
+      const installDir = mkdtempSync(join(tmpdir(), 'openclaw-plugin-install-'));
 
-      execSync("pnpm clean", {
-        cwd: pluginPackageDir,
-        stdio: "pipe",
-      });
+      try {
+        if (!existsSync(pluginRuntimeDistPath)) {
+          execSync('pnpm build', {
+            cwd: pluginPackageDir,
+            stdio: 'pipe',
+          });
+        }
 
-      expect(existsSync(coreDistIndex)).toBe(true);
+        execSync(`pnpm pack --pack-destination "${packDir}"`, {
+          cwd: pluginPackageDir,
+          stdio: 'pipe',
+        });
+
+        const tarball = readdirSync(packDir).find((name) => name.endsWith('.tgz'));
+        expect(tarball).toBeTruthy();
+
+        const tarballPath = join(packDir, tarball ?? '');
+        const packedRuntime = execSync(`tar -xOf "${tarballPath}" package/dist/runtime.js`, {
+          encoding: 'utf8',
+        });
+        expect(hasRuntimeImportEdge(packedRuntime)).toBe(false);
+        expect(packedRuntime).toContain('@ghostwater/vault-engine-openclaw');
+
+        writeFileSync(
+          join(installDir, 'package.json'),
+          JSON.stringify(
+            {
+              name: 'openclaw-plugin-pack-test',
+              private: true,
+              type: 'module',
+            },
+            null,
+            2
+          ) + '\n',
+          'utf8'
+        );
+
+        execSync(`pnpm install "${tarballPath}"`, {
+          cwd: installDir,
+          stdio: 'pipe',
+        });
+
+        expect(() =>
+          execSync(
+            [
+              'node --input-type=module -e',
+              `"import { pathToFileURL } from 'node:url';`,
+              "import { resolve } from 'node:path';",
+              "const runtimePath = resolve('node_modules/@ghostwater/vault-engine-openclaw/dist/runtime.js');",
+              'await import(pathToFileURL(runtimePath).href);"',
+            ].join(' '),
+            { cwd: installDir, stdio: 'pipe' }
+          )
+        ).not.toThrowError(/Cannot find (module|package) ['"]@ghostwater\/vault-engine['"]/);
+      } finally {
+        rmSync(packDir, { recursive: true, force: true });
+        rmSync(installDir, { recursive: true, force: true });
+      }
     },
     120_000
   );

--- a/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
+++ b/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
@@ -1,0 +1,30 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(__dirname, "../../..");
+const coreDistIndex = resolve(repoRoot, "packages/core/dist/index.js");
+const pluginPackageDir = resolve(repoRoot, "packages/openclaw-plugin");
+
+describe("openclaw plugin packaging CI isolation", () => {
+  it(
+    "does not delete core build artifacts when running plugin clean",
+    () => {
+      execSync("pnpm build", {
+        cwd: repoRoot,
+        stdio: "pipe",
+      });
+      expect(existsSync(coreDistIndex)).toBe(true);
+
+      execSync("pnpm clean", {
+        cwd: pluginPackageDir,
+        stdio: "pipe",
+      });
+
+      expect(existsSync(coreDistIndex)).toBe(true);
+    },
+    120_000
+  );
+});

--- a/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
+++ b/packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
@@ -54,6 +54,14 @@ describe('openclaw plugin packaging CI follow-up', () => {
               name: 'openclaw-plugin-pack-test',
               private: true,
               type: 'module',
+              pnpm: {
+                overrides: {
+                  chokidar: '5.0.0',
+                  'gray-matter': '4.0.3',
+                  minisearch: '7.2.0',
+                  stemmer: '2.0.1',
+                },
+              },
             },
             null,
             2


### PR DESCRIPTION
## Summary
- replaces the CI follow-up packaging test in packages/openclaw-plugin with runtime-edge detection that only matches real import/require forms of @ghostwater/vault-engine
- validates the packed tarball by installing it into a temp external project and loading installed dist/runtime.js (instead of importing directly from unpacked tar contents without deps)
- removes workspace-mutating clean behavior from the test path; no pnpm clean is executed during tests, preventing packages/core/dist deletion cascades

## Scope
- packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts only

## Validation
- pnpm test -- --run packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
- pnpm test -- --run bin/vault.test.ts
- pnpm test -- --run packages/openclaw-plugin/src/index.test.ts packages/openclaw-plugin/src/package-bundle-ci-followup.test.ts
- pnpm build
- pnpm test
