### PR TITLE
security: harden CI dependency cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,9 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build (typecheck)
         run: pnpm build


### PR DESCRIPTION
## Summary
- Remove broad pnpm cache restore fallback from PR CI
- Use `pnpm install --frozen-lockfile` in CI

## Validation
- `git diff --check`
- Targeted scan confirmed the broad `restore-keys` fallback and non-frozen pnpm install are gone